### PR TITLE
Fix Elixir matrix CI template

### DIFF
--- a/templates/elixir-ci.yaml
+++ b/templates/elixir-ci.yaml
@@ -14,13 +14,18 @@ env:
   ELIXIR_VERSION: 1.14.3
   OTP_VERSION: 25
   MIX_ENV: test
-  ELIXIR_VERSION_OBS: 1.13.4
-  OTP_VERSION_OBS: 22
 
 jobs:
   elixir-deps:
-    name: Elixir dependencies
+    name: Elixir dependencies (Elixir ${{ matrix.elixir }}, OTP ${{ matrix.otp }})
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          - elixir: 1.14.3
+            otp: 25
+          - elixir: 1.13.4
+            otp: 22
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -29,8 +34,8 @@ jobs:
       - name: Setup
         uses: erlef/setup-beam@v1
         with:
-          elixir-version: ${{ env.ELIXIR_VERSION }}
-          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ matrix.elixir }}
+          otp-version: ${{ matrix.otp }}
         env:
           ImageOS: ubuntu20
       - name: Retrieve Cached Dependencies
@@ -41,7 +46,7 @@ jobs:
             deps
             _build/test
             priv/plts
-          key: ${{ runner.os }}-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('mix.lock') }}
+          key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('mix.lock') }}
       - name: Install Dependencies
         if: steps.mix-cache.outputs.cache-hit != 'true'
         run: |
@@ -93,10 +98,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: ${{ env.ELIXIR_VERSION }}
-            otp: ${{ env.OTP_VERSION }}
-          - elixir: ${{ env.ELIXIR_VERSION_OBS }}
-            otp: ${{ env.OTP_VERSION_OBS }}
+          - elixir: 1.14.3
+            otp: 25
+          - elixir: 1.13.4
+            otp: 22
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR fixes changes from commit f5581a0. Namely that you cannot reference `env` variables from inside a `matrix` definition.

As a result, the same versioning info has to be populated across all CI steps that use the `matrix` feature.

See https://github.com/orgs/community/discussions/26388