### PR TITLE
Pin version of all CI runners

### DIFF
--- a/templates/elixir-ci.yaml
+++ b/templates/elixir-ci.yaml
@@ -128,7 +128,7 @@ jobs:
 
   generate-docs:
     name: Generate project documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.event_name == 'push' && github.ref_name == 'main'
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
As the title says. Going forward, all  CI runners' versions will be pinned instead of using `-latest` to avoid compatibility issues.