### PR TITLE
Compile and test with --warnings-as-errors flag

### DIFF
--- a/templates/elixir-ci.yaml
+++ b/templates/elixir-ci.yaml
@@ -121,10 +121,12 @@ jobs:
             _build/test
             priv/plts
           key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('mix.lock') }}
+      - name: Compile
+        run: mix compile --warnings-as-errors
       - name: Run test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mix coveralls.github --color --trace
+        run: mix coveralls.github --warnings-as-errors --color --trace
 
   generate-docs:
     name: Generate project documentation


### PR DESCRIPTION
Add `--warnings-as-errors` to the ci template