### PR TITLE
Fix cache-miss in CI pipeline

### DIFF
--- a/templates/elixir-ci.yaml
+++ b/templates/elixir-ci.yaml
@@ -165,9 +165,46 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./doc
+
+  main-branch-deps:
+    name: Rebuild main branch dependencies
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          access_token: ${{ github.token }}
+      - name: Set up Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+          otp-version: ${{ env.OTP_VERSION }}
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+      - name: Retrieve Cached Dependencies - main branch
+        uses: actions/cache@v3
+        id: mix-cache-main
+        with:
+          path: |
+            deps
+            _build/test
+            priv/plts
+          key: ${{ runner.os }}-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('mix.lock') }}
+      - name: Install missing dependencies
+        if: steps.mix-cache-main.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p priv/plts
+          mix local.rebar --force
+          mix local.hex --force
+          mix deps.get
+          mix deps.compile --warnings-as-errors
+          mix dialyzer --plt
+
   api-bc-check:
     name: API bc check
-    needs: [elixir-deps]
+    needs: [elixir-deps, main-branch-deps]
     runs-on: ubuntu-20.04
     strategy:
       # Strategy matrix might not be strictly necessary if there is only one API version

--- a/templates/elixir-ci.yaml
+++ b/templates/elixir-ci.yaml
@@ -169,6 +169,7 @@ jobs:
   main-branch-deps:
     name: Rebuild main branch dependencies
     runs-on: ubuntu-20.04
+    if: github.ref_name != 'main'
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.11.0


### PR DESCRIPTION
# Description

This PR rebuilds the `main` branch dependencies if they are missing, in order to allow the `BC-check` step to run.