### PR TITLE
Fix link to CI template for Elixir

### DIFF
--- a/coding-standards/elixir.md
+++ b/coding-standards/elixir.md
@@ -26,7 +26,7 @@ The [Catalog of Elixir-specific Code Smells](https://github.com/lucasvegi/Elixir
 
 ## CI
 
-Please use the [elixir.yml template](../templates/elixir.yml) as a starting point for your project.
+Please use the [CI template](../templates/elixir-ci.yaml) as a starting point for your project.
 
 ## Documentation
 


### PR DESCRIPTION
I've noticed this while reading the file.