### PR TITLE
Update manual installation guide  for oidc integration

### DIFF
--- a/guides/manual-installation.md
+++ b/guides/manual-installation.md
@@ -247,7 +247,6 @@ AMQP_URL=amqp://trento_user:trento_user_password@localhost:5672/vhost
 DATABASE_URL=ecto://trento_user:web_password@localhost/trento
 EVENTSTORE_URL=ecto://trento_user:web_password@localhost/trento_event_store
 ENABLE_ALERTING=false
-ENABLE_OIDC=false
 CHARTS_ENABLED=true
 PROMETHEUS_URL=http://localhost:9090
 ADMIN_USER=admin
@@ -392,7 +391,6 @@ journalctl -fu trento-web
     --add-host "host.docker.internal:host-gateway" \
     -e AMQP_URL=amqp://trento_user:trento_user_password@host.docker.internal/vhost \
     -e ENABLE_ALERTING=false \
-    -e ENABLE_OIDC=false  \
     -e DATABASE_URL=ecto://trento_user:web_password@host.docker.internal/trento \
     -e EVENTSTORE_URL=ecto://trento_user:web_password@host.docker.internal/trento_event_store \
     -e PROMETHEUS_URL='http://host.docker.internal:9090' \
@@ -494,7 +492,7 @@ All roles and permissions should be managed by the newly created admin user with
 
 OIDC authentication is **disabled by default**.
 
-##### Enabling OIDC RPM
+##### Enabling OIDC when using RPM packages
 
 Provide the following environment variables to trento-web configuration, which is stored at ```/etc/trento/trento-web```  and restart the application to enable OIDC integration.
 
@@ -509,11 +507,11 @@ OIDC_BASE_URL=<<OIDC_BASE_URL>>
 OIDC_CALLBACK_URL=<<OIDC_CALLBACK_URL>>
 
 ```
-##### Enabling OIDC Docker
+##### Enabling OIDC when using Docker images
 
 Provide the following environment variables to the docker container and restart the application to enable OIDC integration.
 
-```
+```bash
 docker run -d \
 -p 4000:4000 \
 --name trento-web \

--- a/guides/manual-installation.md
+++ b/guides/manual-installation.md
@@ -475,18 +475,12 @@ Expected output if Trento web/wanda is ready and the database connection is setu
 
 Trento integrates with an identity provider (IDP) that uses the OpenID Connect (OIDC) protocol to authenticate users accessing the Trento web console. Authorization for specific abilities/permissions is managed by Trento, which means that only basic user information is retrieved from the external IDP.
 
-
 #### User Roles and Authentication
 
 User authentication is entirely managed by the IDP, which is responsible for maintaining user accounts. 
 A user, who does not exist on the IDP, is unable to access the Trento web console.
-If the default admin user created during the installation process matches the authenticated user’s IDP username, that user is automatically granted `all:all` permissions within Trento.
-Create a new user on IDP and login to Trento to finalize the user creation on Trento.
-Set `all:users` permissions with the default admin user to the newly created admin user.
-
-All roles and permissions should be managed by the newly created admin user with the `all:users` permissions inside Trento, independent of the IDP.
-
-> **Note:** Multi-Factor Authentication cannot be enabled for the default admin user, keeping its password safe is essential
+During the installation process, a default admin user is defined using the `ADMIN_USER` variable, which defaults to `admin`. If the authenticated user’s IDP username matches this default admin user's username, that user is automatically granted `all:all` permissions within Trento.
+User permissions are entirely managed by Trento, they are not imported from the IDP. The abilities must be granted by some user with `all:all` or `all:users` abilities (**admin user initially**).
 
 #### Enabling OIDC
 

--- a/guides/manual-installation.md
+++ b/guides/manual-installation.md
@@ -247,6 +247,7 @@ AMQP_URL=amqp://trento_user:trento_user_password@localhost:5672/vhost
 DATABASE_URL=ecto://trento_user:web_password@localhost/trento
 EVENTSTORE_URL=ecto://trento_user:web_password@localhost/trento_event_store
 ENABLE_ALERTING=false
+ENABLE_OIDC=false
 CHARTS_ENABLED=true
 PROMETHEUS_URL=http://localhost:9090
 ADMIN_USER=admin
@@ -391,6 +392,7 @@ journalctl -fu trento-web
     --add-host "host.docker.internal:host-gateway" \
     -e AMQP_URL=amqp://trento_user:trento_user_password@host.docker.internal/vhost \
     -e ENABLE_ALERTING=false \
+    -e ENABLE_OIDC=false  \
     -e DATABASE_URL=ecto://trento_user:web_password@host.docker.internal/trento \
     -e EVENTSTORE_URL=ecto://trento_user:web_password@host.docker.internal/trento_event_store \
     -e PROMETHEUS_URL='http://host.docker.internal:9090' \
@@ -468,6 +470,61 @@ Expected output if Trento web/wanda is ready and the database connection is setu
 ```
 {"ready":true}{"database":"pass"}
 ```
+
+## Integrations
+
+### OIDC
+
+Trento supports OpenID Connect (OIDC) protocol to authenticate users accessing the Trento web console. 
+
+#### Enabling OIDC
+
+The OIDC authentication is **disabled by default**.
+
+##### Enabling OIDC RPM
+
+Provide the following environment variables to trento-web configuration, which is stored at ```/etc/trento/trento-web```  and restart the application to enable OIDC integration.
+
+```
+# Required:
+ENABLE_OIDC=true
+OIDC_CLIENT_ID=<<OIDC_CLIENT_ID>>
+OIDC_CLIENT_SECRET=<<OIDC_CLIENT_SECRET>>
+OIDC_BASE_URL=<<OIDC_BASE_URL>>
+
+# Optional:
+OIDC_CALLBACK_URL=<<OIDC_CALLBACK_URL>>
+
+```
+##### Enabling OIDC Docker
+
+Provide the following environment variables to the docker container and restart the application to enable OIDC integration.
+
+```
+docker run -d \
+-p 4000:4000 \
+--name trento-web \
+--network trento-net \
+--add-host "host.docker.internal:host-gateway" \
+
+...[other settings]...
+
+# REQUIRED:
+-e ENABLE_OIDC=true  \
+-e OIDC_CLIENT_ID=<<OIDC_CLIENT_ID>> \
+-e OIDC_CLIENT_SECRET=<<OIDC_CLIENT_SECRET>> \
+-e OIDC_BASE_URL=<<OIDC_BASE_URL>> \
+
+# OPTIONAL:
+-e OIDC_CALLBACK_URL=<<OIDC_CALLBACK_URL>> \
+
+...[other settings]...
+```
+
+
+#### Trento OIDC super admin
+
+The super admin user association is done using the `ADMIN_USER` variable, so any user with that name in the provided IDP will be granted with that permissions.
 
 ## Prepare SSL certificate for NGINX
 

--- a/guides/manual-installation.md
+++ b/guides/manual-installation.md
@@ -479,7 +479,7 @@ Trento integrates with an identity provider (IDP) that uses the OpenID Connect (
 
 User authentication is entirely managed by the IDP, which is responsible for maintaining user accounts. 
 A user, who does not exist on the IDP, is unable to access the Trento web console.
-During the installation process, a default admin user is defined using the `ADMIN_USER` variable, which defaults to `admin`. If the authenticated user’s IDP username matches this default admin user's username, that user is automatically granted `all:all` permissions within Trento.
+During the installation process, a default admin user is defined using the `ADMIN_USER` variable, which defaults to `admin`. If the authenticated user’s IDP username matches this admin user's username, that user is automatically granted `all:all` permissions within Trento.
 User permissions are entirely managed by Trento, they are not imported from the IDP. The abilities must be granted by some user with `all:all` or `all:users` abilities (**admin user initially**).
 
 #### Enabling OIDC

--- a/guides/manual-installation.md
+++ b/guides/manual-installation.md
@@ -473,13 +473,26 @@ Expected output if Trento web/wanda is ready and the database connection is setu
 
 ## Integrations
 
-### OIDC
+### OpenID Connect
 
-Trento supports OpenID Connect (OIDC) protocol to authenticate users accessing the Trento web console. 
+Trento integrates with an identity provider (IDP) that uses the OpenID Connect (OIDC) protocol to authenticate users accessing the Trento web console. Authorization for specific abilities/permissions is managed by Trento, which means that only basic user information is retrieved from the external IDP.
+
+
+#### User Roles and Authentication
+
+User authentication is entirely managed by the IDP, which is responsible for maintaining user accounts. 
+A user, who does not exist on the IDP, is unable to access the Trento web console.
+If the default admin user created during the installation process matches the authenticated user’s IDP username, that user is automatically granted `all:all` permissions within Trento.
+Create a new user on IDP and login to Trento to finalize the user creation on Trento.
+Set `all:users` permissions with the default admin user to the newly created admin user.
+
+All roles and permissions should be managed by the newly created admin user with the `all:users` permissions inside Trento, independent of the IDP.
+
+> **Note:** Multi-Factor Authentication cannot be enabled for the default admin user, keeping its password safe is essential
 
 #### Enabling OIDC
 
-The OIDC authentication is **disabled by default**.
+OIDC authentication is **disabled by default**.
 
 ##### Enabling OIDC RPM
 
@@ -520,11 +533,6 @@ docker run -d \
 
 ...[other settings]...
 ```
-
-
-#### Trento OIDC super admin
-
-The super admin user association is done using the `ADMIN_USER` variable, so any user with that name in the provided IDP will be granted with that permissions.
 
 ## Prepare SSL certificate for NGINX
 


### PR DESCRIPTION
This pr adds an Integration chapter for the OIDC implementation. Additionally, we can add further integrations like oauth2 and SAML as subchapters. This can become an own section in the official [Trento documentation](https://documentation.suse.com/sles-sap/trento/html/SLES-SAP-trento/index.html#sec-trento-installing-trentoserver).

We may need to discuss the structure where to put it, but we could migrate it to [chapter 4 ](https://documentation.suse.com/sles-sap/trento/html/SLES-SAP-trento/index.html#sec-trento-installing-trentoserver)
as point 4.4 Integration options with references to 4.2 systemd deployment and 4.3 Containerized deployment.



Let's see, I would suppose to finish the documentation for the other Protocols first and then take care for the migration.

@abravosuse what do you think?
