### PR TITLE
Add operation endpoing nginx rule

### DIFF
--- a/guides/manual-installation.adoc
+++ b/guides/manual-installation.adoc
@@ -1312,7 +1312,7 @@ server {
     ssl_session_cache shared:SSL:10m;
 
     # Wanda rule
-    location ~ ^/(api/checks|api/v1/checks|api/v2/checks|api/v3/checks|api/groups|api/v1/groups)/  {
+    location ~ ^/(api/checks|api/v1/checks|api/v2/checks|api/v3/checks|api/groups|api/v1/groups|api/operations|api/v1/operations)/  {
         allow all;
 
         # Proxy Headers


### PR DESCRIPTION
Add new `/api/v1/operations` endpoint nginx rule to nginx configuration.

PD: related, I have sent a similar patch to the official docs repo: https://github.com/SUSE/doc-unversioned/pull/206