### PR TITLE
Add the docs dir of ansible repo

### DIFF
--- a/trento-docs-site/antora.yml
+++ b/trento-docs-site/antora.yml
@@ -87,6 +87,9 @@ ext:
       - dir: trento-docs-site/tmp_docs/ansible
         files: '*.adoc'
         into: modules/ansible/pages
+      - dir: trento-docs-site/tmp_docs/ansible/docs
+        files: '*.adoc'
+        into: modules/ansible/pages
     ## Trento Checks https://github.com/trento-project/checks
     - scan:
       - dir: trento-docs-site/tmp_docs/checks

--- a/trento-docs-site/modules/developer/nav_developer.adoc
+++ b/trento-docs-site/modules/developer/nav_developer.adoc
@@ -47,6 +47,7 @@
 **** xref:ROOT:agent:development/how-to-make-a-release.adoc[How to release a new version of Trento Agent]
 
 *** xref:ROOT:ansible:README.adoc[Trento Ansible]
+**** xref:ROOT:ansible:local-development-environment.adoc[Local Development Environment]
 
 *** xref:ROOT:checks:README.adoc[Trento Checks]
 


### PR DESCRIPTION
This is a follow up pr to include the docs directory of the ansible repo. 
See docs change at https://github.com/trento-project/ansible/pull/62
