### PR TITLE
Add new checks customization article to the user guide

### DIFF
--- a/trento-docs-site/modules/user-guide/nav_user_guide.adoc
+++ b/trento-docs-site/modules/user-guide/nav_user_guide.adoc
@@ -8,6 +8,7 @@
  ** xref:trento-sso-integration.adoc[Single Sign-On integration]
  ** xref:trento-activity-log.adoc[Activity Log]
  ** xref:trento-checks.adoc[Performing configuration checks]
+ ** xref:trento-checks-customization.adoc[Checks Customization]
  ** xref:trento-web-console.adoc[Using Trento Web]
  ** xref:trento-housekeeping.adoc[Housekeeping]
  ** xref:trento-manage-tags.adoc[Managing tags]


### PR DESCRIPTION
This pr adds the new released 2.5 article to the navigation bar, same as in the official guide https://documentation.suse.com/sles-sap/trento/html/SLES-SAP-trento/sec-trento-checks.html#checks_customization

Demo of left nav bar: 
<img width="1121" height="441" alt="image" src="https://github.com/user-attachments/assets/d66529c3-986d-4a33-86cc-e7b1dadd6503" />


