### PR TITLE
[TRNT-3845] Expose Wanda docs

### DIFF
--- a/trento/adoc/trento-systemd-install.adoc
+++ b/trento/adoc/trento-systemd-install.adoc
@@ -575,13 +575,15 @@ server {
 
     # Web rule
     location / {
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-        proxy_set_header Host $host;
-        proxy_cache_bypass $http_upgrade;
+        allow all;
 
-        # The Important Websocket Bits!
+        # Proxy Headers
+        proxy_http_version 1.1;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Cluster-Client-Ip $remote_addr;
+
+        # Important Websocket Bits!
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
 


### PR DESCRIPTION
# Description

This PR introduces changes in the suggested nginx config to expose the Wanda API documentation as well. For now, it's `/wanda/api/(v[0-9]+|latest|all|unversioned)/openapi` and `/wanda/api/doc`.

~Still a draft as I need to verify it works as expected~, but, for now, I want to open up the discussion as soon as possible.

Related TRNT-3845

Sibling PR: https://github.com/trento-project/ansible/pull/68

## How was this tested?

IRL test, see the script below

<img width="730" height="511" alt="image" src="https://github.com/user-attachments/assets/1ea8dd04-ff47-4e2d-ab6b-f648957f6743" />


<details><summary>script</summary>

````bash
# Helper: assert that the output of a command matches the expected value
# Usage: assert_eq "command..." "expected_value"
assert_eq() {
	local output
	output=$(eval "$1")
	if [[ "$output" != "$2" ]]; then
		echo "Assertion failed: $1 => '$output' (expected '$2')" >&2
		exit 1
	fi
}

# Trento API JSON files, already working
assert_eq "curl -Lks 'https://localhost/api/v1/openapi' | jq -r .info.title" "Trento"
assert_eq "curl -Lks 'https://localhost/api/v2/openapi' | jq -r .info.title" "Trento"
assert_eq "curl -Lks 'https://localhost/api/v3/openapi' | jq -r .info.title" "null"
assert_eq "curl -Lks 'https://localhost/api/all/openapi' | jq -r .info.title" "Trento"
assert_eq "curl -Lks 'https://localhost/api/unversioned/openapi' | jq -r .info.title" "Trento"

# Trento API doc portal, already working
code=$(curl -Lks -o /dev/null -w "%{http_code}\n" 'https://localhost/api/doc')
if [[ "$code" != "200" ]]; then
	echo "Assertion failed: /api/doc returned $code (expected 200)" >&2
	exit 1
fi

# Wanda API JSON files, added in this PR
assert_eq "curl -Lks 'https://localhost/wanda/api/v1/openapi' | jq -r .info.title" "Wanda"
assert_eq "curl -Lks 'https://localhost/wanda/api/v2/openapi' | jq -r .info.title" "Wanda"
assert_eq "curl -Lks 'https://localhost/wanda/api/v3/openapi' | jq -r .info.title" "Wanda"
assert_eq "curl -Lks 'https://localhost/wanda/api/all/openapi' | jq -r .info.title" "Wanda"
assert_eq "curl -Lks 'https://localhost/wanda/api/unversioned/openapi' | jq -r .info.title" "Wanda"

# Wanda API doc portal, added in this PR
code=$(curl -Lks -o /dev/null -w "%{http_code}\n" 'https://localhost/wanda/api/doc')
if [[ "$code" != "200" ]]; then
	echo "Assertion failed: /wanda/api/doc returned $code (expected 200)" >&2
	exit 1
fi

# Wanda API JSON files, when loaded from the Wanda docs portal, added in this PR
assert_eq "curl -Lks 'https://localhost/api/v1/openapi' -H 'referer: https://localhost/wanda/api/doc' | jq -r .info.title" "Wanda"
assert_eq "curl -Lks 'https://localhost/api/v2/openapi' -H 'referer: https://localhost/wanda/api/doc' | jq -r .info.title" "Wanda"
assert_eq "curl -Lks 'https://localhost/api/v3/openapi' -H 'referer: https://localhost/wanda/api/doc' | jq -r .info.title" "Wanda"
assert_eq "curl -Lks 'https://localhost/api/all/openapi' -H 'referer: https://localhost/wanda/api/doc' | jq -r .info.title" "Wanda"
assert_eq "curl -Lks 'https://localhost/api/unversioned/openapi' -H 'referer: https://localhost/wanda/api/doc' | jq -r .info.title" "Wanda"
```
</details> 