### PR TITLE
Add 3.0 to compatibility matrix

### DIFF
--- a/trento/adoc/trento-compatibility.adoc
+++ b/trento/adoc/trento-compatibility.adoc
@@ -4,20 +4,20 @@ include::product-attributes.adoc[]
 == Compatibility matrix between {trserver} and {tragent}s
 :revdate: 2025-06-10
 
-
 .Compatibility matrix between {trserver} and {tragent}s
-[cols="^1,^1,^1,^1,^1,^1,^1,^1,^1,^1", options="header"]
+[cols="^1,^1,^1,^1,^1,^1,^1,^1,^1,^1,^1", options="header"]
 |===
-^|{tragent} 9+^|{trserver}|
-|1.0 |1.1 |1.2 |2.0 |2.1 |2.2 |2.3 |2.4 |2.5
+^|{tragent} 10+^|{trserver}
+| |1.0 |1.1 |1.2 |2.0 |2.1 |2.2 |2.3 |2.4 |2.5 |3.0
 
-|1.0 |[.green]#✓# |[.green]#✓# |[.green]#✓# | | | | | |
-|1.1 | |[.green]#✓# |[.green]#✓# | | | | | |
-|1.2 | | |[.green]#✓# | | | | | |
-|2.0 | | | |[.green]#✓# |[.green]#✓# |[.green]#✓# |[.green]#✓# |[.green]#✓# |[.green]#✓#
-|2.1 | | | | |[.green]#✓# |[.green]#✓# |[.green]#✓# |[.green]#✓# |[.green]#✓#
-|2.2 | | | | | |[.green]#✓# |[.green]#✓# |[.green]#✓# |[.green]#✓#
-|2.3 | | | | | | |[.green]#✓# |[.green]#✓# |[.green]#✓#
-|2.4 | | | | | | | |[.green]#✓# |[.green]#✓#
-|2.5 | | | | | | | | |[.green]#✓#
+|1.0 |[.green]#✓# |[.green]#✓# |[.green]#✓# | | | | | | |
+|1.1 | |[.green]#✓# |[.green]#✓# | | | | | | |
+|1.2 | | |[.green]#✓# | | | | | | |
+|2.0 | | | |[.green]#✓# |[.green]#✓# |[.green]#✓# |[.green]#✓# |[.green]#✓# |[.green]#✓# |
+|2.1 | | | | |[.green]#✓# |[.green]#✓# |[.green]#✓# |[.green]#✓# |[.green]#✓# |
+|2.2 | | | | | |[.green]#✓# |[.green]#✓# |[.green]#✓# |[.green]#✓# |
+|2.3 | | | | | | |[.green]#✓# |[.green]#✓# |[.green]#✓# |
+|2.4 | | | | | | | |[.green]#✓# |[.green]#✓# |
+|2.5 | | | | | | | | |[.green]#✓# |
+|3.0 | | | | | | | | | | [.green]#✓#
 |===


### PR DESCRIPTION
This pr updates the compatibility matrix 3.0

## Before:
<img width="1218" height="1177" alt="image" src="https://github.com/user-attachments/assets/ebda5528-4a22-4082-b552-7bc8cb5be5c6" />


## After: 
<img width="1218" height="1177" alt="image" src="https://github.com/user-attachments/assets/140e7752-8168-471d-a86c-5a91d5a941de" />

Need to test, and check if migration guide required.

