### PR TITLE
Restore the sle 16 mentions

### DIFF
--- a/trento/adoc/trento-lifecycle.adoc
+++ b/trento/adoc/trento-lifecycle.adoc
@@ -12,7 +12,7 @@ include::product-attributes.adoc[]
 +
 Delivery mechanism::: RPM package for {sles4sap} 15 SP3 and newer.
 
-Supported runtime::: Supported in {sles4sap} 15 SP3 and newer, on x86_64 and ppc64le architectures.
+Supported runtime::: Supported in {sles4sap} 15 SP4 and newer, and {sles4sap} 16.0, on x86_64 and ppc64le architectures.
 
 // Variable List for trserver
 {trserver}::
@@ -25,4 +25,4 @@ Delivery mechanisms::: A set of container images from the {suse} public registry
 * If you don't have a {k8s} cluster, and need enterprise support, {suse} recommends {rke} (RKE) version 2.
 * If you do not have a {k8s} enterprise solution but you want to try {trento}, {suse} Rancher's K3s provides you with an easy way to get started. But keep in mind that K3s default installation process deploys a single node {k8s} cluster, which is not a recommended setup for a stable Trento production instance.
 
-systemd deployments::: Supported in {sles4sap} 15 SP3 and newer.
+systemd deployments::: Supported in {sles4sap} 15 SP4 and newer, and {sles4sap} 16.0.

--- a/trento/adoc/trento-report-issue.adoc
+++ b/trento/adoc/trento-report-issue.adoc
@@ -5,7 +5,7 @@ include::product-attributes.adoc[]
 :revdate: 2025-10-27
 
 
-{suse} customers with registered {sles4sap}{nbsp}15 (SP3 or higher)
+{suse} customers with registered {sles4sap} {nbsp} 15 (SP4 or higher) or {sles4sap} 16.0
 distributions can report {trento} issues either directly in the {scc}
 or through the corresponding vendor, depending on their licensing model.
 Problems must be reported under {sles4sap}{nbsp}15 and component

--- a/trento/adoc/trento-requirements.adoc
+++ b/trento/adoc/trento-requirements.adoc
@@ -55,5 +55,5 @@ Similarly, the clusters must have unique authkeys in order to be registered in {
 [[sec-trento-installation-prerequisites]]
 === Installation prerequisites
 
-* *{trserver}* For a {k8s}-based deployment, you must have access to {suse} public registry for the deployment of {trserver} containers. For a systemd deployment, you must have a registered {sles4sap} 15 (SP3 or higher) distribution.
+* *{trserver}* For a {k8s}-based deployment, you must have access to {suse} public registry for the deployment of {trserver} containers. For a systemd deployment, you must have a registered {sles4sap} 15 (SP4 or higher) or {sles4sap} 16.0 distribution.
 * *{tragent}s* A registered {sles4sap} 15 (SP3 or higher) distribution.


### PR DESCRIPTION
This pr restores all mentions of sle 16.0 for the prerelease and the upcomign trento 3.0 docs.
It was originally removed for the clean update state of trento 2.5 docs https://github.com/trento-project/docs/commit/983466e4027c4990673ae7eeddb759dae89119f5