### PR TITLE
Grafana Alloy integration

### DIFF
--- a/content/rfc/0003-grafana-alloy-integration.adoc
+++ b/content/rfc/0003-grafana-alloy-integration.adoc
@@ -678,10 +678,11 @@ WARNING: Running without authentication in production is not recommended. Anyone
 
 ==== Trento Out-of-the-Box Installations
 
-For Trento's provided installation methods, bearer token authentication is pre-configured:
+For Trento's provided installation methods, we want to provide a sane default configuration that does not add unwanted operational effort for the average user, while allowing advanced users to customize the setup as needed.
 
-* **systemd deployments**: nginx is configured with bearer token validation
-* **Helm deployments**: Kubernetes Ingress is configured with bearer token validation
+We will provide a default configuration where bearer token authentication in place on both ansible playbook and helm chart installation scripts.
+
+For both scenarios we configure the reverse proxy to validate bearer tokens for the Prometheus remote write endpoint. The token is meant to be long-lived and static, as it is used by multiple agents.
 
 == Handling Edge Cases
 


### PR DESCRIPTION
This RFC should serve as a blueprint for integrating system metrics with Prometheus on Grafana Alloy-based system.

The integration is needed because SLES >= 16 does not ship `node_expoter` anymore; instead, the default collector tool is Grafana Alloy.

The main goal of the RFC is to reach **feature parity** with the current solution both in terms of collected metrics and user experience.