### PR TITLE
[TRNT-4317] Pin GHA to SHA instead of tags

### DIFF
--- a/.github/workflows/build-page.yaml
+++ b/.github/workflows/build-page.yaml
@@ -20,13 +20,13 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         fetch-depth: 0
     - name: Configure Pages
-      uses: actions/configure-pages@v5
+      uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
     - name: Install Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: '18'
     - name: Install Antora with the Antora Lunr Extension
@@ -36,9 +36,9 @@ jobs:
       working-directory: trento-docs-site
       run: npx antora antora-playbook.yml
     - name: Upload Artifacts
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
       with:
         path: trento-docs-site/build/trento-docs-site-public
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/extension-tests.yaml
+++ b/.github/workflows/extension-tests.yaml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/validate-suse-docs.yaml
+++ b/.github/workflows/validate-suse-docs.yaml
@@ -25,22 +25,22 @@ jobs:
       allow-build: ${{ steps.select-dc-build.outputs.allow-build }}
       relevant-branches: ${{ steps.select-dc-build.outputs.relevant-branches }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Checking basic soundness of DC files
-        uses: openSUSE/doc-ci@gha-select-dcs
+        uses: openSUSE/doc-ci@e349aced35306105cd981adfa9243836deb119ea # gha-select-dcs
         with:
           mode: soundness
 
       - name: Selecting DC files to validate
         id: select-dc-validate
-        uses: openSUSE/doc-ci@gha-select-dcs
+        uses: openSUSE/doc-ci@e349aced35306105cd981adfa9243836deb119ea # gha-select-dcs
         with:
           mode: list-validate
 
       - name: Selecting DC files to build
         id: select-dc-build
-        uses: openSUSE/doc-ci@gha-select-dcs
+        uses: openSUSE/doc-ci@e349aced35306105cd981adfa9243836deb119ea # gha-select-dcs
         with:
           mode: list-build
           original-org: trento-project
@@ -54,8 +54,8 @@ jobs:
       matrix:
         dc-files: ${{ fromJson(needs.select-dc-files.outputs.validate-list) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Validating DC file(s) ${{ matrix.dc-files }}
-        uses: openSUSE/doc-ci@gha-validate
+        uses: openSUSE/doc-ci@bd6cbd0ef4bb85994839ef42cf904a2ce08b55fd # gha-validate
         with:
           dc-files: ${{ matrix.dc-files }}


### PR DESCRIPTION
# Description

As security incidents are popping up constantly, it is a good practice to pin the GHA to a specific SHA instead of tags, in case the GHA repository gets compromised. This PR replaces all the versions with the specific SHA.

Related # TRNT-4317


```
==> Summary
    Total uses: references found : 13
    Already pinned (SHA)         : 0
    Pinned in this run           : 13
    Resolved from cache          : 7
    Hardcoded overrides applied  : 0
    Private/inaccessible (logged): 0
    Failed to resolve            : 0
```

## How was this tested?

N/A

