### PR TITLE
[TRNT-4358] Add license headers

### DIFF
--- a/.github/workflows/build-page.yaml
+++ b/.github/workflows/build-page.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 name: Publish Trento documentation on GitHub Pages
 on:
   push:

--- a/.github/workflows/extension-tests.yaml
+++ b/.github/workflows/extension-tests.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 name: Run Trento docs extension tests
 
 on:

--- a/.github/workflows/validate-suse-docs.yaml
+++ b/.github/workflows/validate-suse-docs.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 name: Validate user facing documentation
 
 on:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 .env
 .elixir_ls
 

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+header:
+  comment: on-failure
+  license:
+    spdx-id: Apache-2.0
+    copyright-owner: SUSE LLC
+    software-name: trento-docs
+    content: |
+      SPDX-FileCopyrightText: SUSE LLC
+      SPDX-License-Identifier: Apache-2.0
+  paths-ignore:
+    - "**/*.adoc"
+    - "**/*.drawio"
+    - "**/*.dump"
+    - "**/*.eslintrc"
+    - "**/*.hbs"
+    - "**/*.json"
+    - "**/*.nvmrc"
+    - "**/*.stylelintrc"
+    - "**/*.svg"
+    - ".github/dependabot.yml"
+    - ".tool-versions"
+    - "LICENSE"
+    - "content/**"
+    - "trento/**"
+
+  language:
+    JavaScript:
+      extensions:
+        - ".js"
+        - ".jsx"
+        - ".mjs"
+        - ".cjs"
+      comment_style_id: DoubleSlash

--- a/dev-docs-env.sh
+++ b/dev-docs-env.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 # Start all services

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 x-node-base: &node-base
   image: node:20-bullseye
 

--- a/trento-docs-site-ui/.editorconfig
+++ b/trento-docs-site-ui/.editorconfig
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 root = true
 
 [*]

--- a/trento-docs-site-ui/docs/antora.yml
+++ b/trento-docs-site-ui/docs/antora.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 name: antora-ui-default
 title: Antora Default UI
 version: ~

--- a/trento-docs-site-ui/docs/modules/ROOT/examples/latest-release-notes.js
+++ b/trento-docs-site-ui/docs/modules/ROOT/examples/latest-release-notes.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 'use strict'
 
 module.exports = (numOfItems, { data }) => {

--- a/trento-docs-site-ui/gulp.d/lib/create-task.js
+++ b/trento-docs-site-ui/gulp.d/lib/create-task.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 'use strict'
 
 const metadata = require('undertaker/lib/helpers/metadata')

--- a/trento-docs-site-ui/gulp.d/lib/export-tasks.js
+++ b/trento-docs-site-ui/gulp.d/lib/export-tasks.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 'use strict'
 
 module.exports = (...tasks) => {

--- a/trento-docs-site-ui/gulp.d/lib/gulp-prettier-eslint.js
+++ b/trento-docs-site-ui/gulp.d/lib/gulp-prettier-eslint.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 'use strict'
 
 const log = require('fancy-log')

--- a/trento-docs-site-ui/gulp.d/tasks/build-preview-pages.js
+++ b/trento-docs-site-ui/gulp.d/tasks/build-preview-pages.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 'use strict'
 
 const Asciidoctor = require('@asciidoctor/core')()

--- a/trento-docs-site-ui/gulp.d/tasks/build.js
+++ b/trento-docs-site-ui/gulp.d/tasks/build.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 'use strict'
 
 const autoprefixer = require('autoprefixer')

--- a/trento-docs-site-ui/gulp.d/tasks/format.js
+++ b/trento-docs-site-ui/gulp.d/tasks/format.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 'use strict'
 
 const prettier = require('../lib/gulp-prettier-eslint')

--- a/trento-docs-site-ui/gulp.d/tasks/index.js
+++ b/trento-docs-site-ui/gulp.d/tasks/index.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 'use strict'
 
 const camelCase = (name) => name.replace(/[-]./g, (m) => m.slice(1).toUpperCase())

--- a/trento-docs-site-ui/gulp.d/tasks/lint-css.js
+++ b/trento-docs-site-ui/gulp.d/tasks/lint-css.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 'use strict'
 
 const stylelint = require('gulp-stylelint')

--- a/trento-docs-site-ui/gulp.d/tasks/lint-js.js
+++ b/trento-docs-site-ui/gulp.d/tasks/lint-js.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 'use strict'
 
 const eslint = require('gulp-eslint')

--- a/trento-docs-site-ui/gulp.d/tasks/pack.js
+++ b/trento-docs-site-ui/gulp.d/tasks/pack.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 'use strict'
 
 const ospath = require('path')

--- a/trento-docs-site-ui/gulp.d/tasks/remove.js
+++ b/trento-docs-site-ui/gulp.d/tasks/remove.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 'use strict'
 
 const fs = require('fs-extra')

--- a/trento-docs-site-ui/gulp.d/tasks/serve.js
+++ b/trento-docs-site-ui/gulp.d/tasks/serve.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 'use strict'
 
 const connect = require('gulp-connect')

--- a/trento-docs-site-ui/gulpfile.js
+++ b/trento-docs-site-ui/gulpfile.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 'use strict'
 
 const { parallel, series, watch } = require('gulp')

--- a/trento-docs-site-ui/index.js
+++ b/trento-docs-site-ui/index.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 'use strict'
   
 // This placeholder script allows this package to be discovered using require.resolve.

--- a/trento-docs-site-ui/preview-src/ui-model.yml
+++ b/trento-docs-site-ui/preview-src/ui-model.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 antoraVersion: '1.0.0'
 site:
   url: http://localhost:5252

--- a/trento-docs-site-ui/src/css/base.css
+++ b/trento-docs-site-ui/src/css/base.css
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: SUSE LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 *,
 *::before,
 *::after {

--- a/trento-docs-site-ui/src/css/body.css
+++ b/trento-docs-site-ui/src/css/body.css
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: SUSE LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 @media screen and (min-width: 1024px) {
   .body {
     display: flex;

--- a/trento-docs-site-ui/src/css/breadcrumbs.css
+++ b/trento-docs-site-ui/src/css/breadcrumbs.css
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: SUSE LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 .breadcrumbs {
   display: none;
   flex: 1 1;

--- a/trento-docs-site-ui/src/css/doc.css
+++ b/trento-docs-site-ui/src/css/doc.css
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: SUSE LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 .doc {
   color: var(--doc-font-color);
   font-size: var(--doc-font-size);

--- a/trento-docs-site-ui/src/css/footer.css
+++ b/trento-docs-site-ui/src/css/footer.css
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: SUSE LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 footer.footer {
   background-color: var(--footer-background);
   color: var(--footer-font-color);

--- a/trento-docs-site-ui/src/css/header.css
+++ b/trento-docs-site-ui/src/css/header.css
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: SUSE LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 @media screen and (max-width: 1023.5px) {
   html.is-clipped--navbar {
     overflow-y: hidden;

--- a/trento-docs-site-ui/src/css/highlight.css
+++ b/trento-docs-site-ui/src/css/highlight.css
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: SUSE LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /*! Adapted from the GitHub style by Vasily Polovnyov <vast@whiteants.net> */
 .hljs-comment,
 .hljs-quote {

--- a/trento-docs-site-ui/src/css/main.css
+++ b/trento-docs-site-ui/src/css/main.css
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: SUSE LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 body.-toc aside.toc.sidebar {
   display: none;
 }

--- a/trento-docs-site-ui/src/css/nav.css
+++ b/trento-docs-site-ui/src/css/nav.css
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: SUSE LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 @media screen and (max-width: 1023.5px) {
   html.is-clipped--nav {
     overflow-y: hidden;

--- a/trento-docs-site-ui/src/css/page-versions.css
+++ b/trento-docs-site-ui/src/css/page-versions.css
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: SUSE LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 .page-versions {
   margin: 0 0.2rem 0 auto;
   position: relative;

--- a/trento-docs-site-ui/src/css/pagination.css
+++ b/trento-docs-site-ui/src/css/pagination.css
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: SUSE LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 nav.pagination {
   display: flex;
   border-top: 1px solid var(--toolbar-border-color);

--- a/trento-docs-site-ui/src/css/print.css
+++ b/trento-docs-site-ui/src/css/print.css
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: SUSE LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 @page {
   margin: 0.5in;
 }

--- a/trento-docs-site-ui/src/css/site.css
+++ b/trento-docs-site-ui/src/css/site.css
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: SUSE LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 @import "typeface-eos-icons.css";
 @import "typeface-roboto.css";
 @import "typeface-roboto-mono.css";

--- a/trento-docs-site-ui/src/css/toc.css
+++ b/trento-docs-site-ui/src/css/toc.css
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: SUSE LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 .toc-menu {
   color: var(--toc-font-color);
 }

--- a/trento-docs-site-ui/src/css/toolbar.css
+++ b/trento-docs-site-ui/src/css/toolbar.css
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: SUSE LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 .toolbar {
   color: var(--toolbar-font-color);
   align-items: center;

--- a/trento-docs-site-ui/src/css/typeface-eos-icons.css
+++ b/trento-docs-site-ui/src/css/typeface-eos-icons.css
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: SUSE LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 @font-face {
   font-family: "eos-icons";
   font-weight: normal;

--- a/trento-docs-site-ui/src/css/typeface-lato.css
+++ b/trento-docs-site-ui/src/css/typeface-lato.css
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: SUSE LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 @font-face {
   font-family: "Lato";
   font-style: normal;

--- a/trento-docs-site-ui/src/css/typeface-roboto-mono.css
+++ b/trento-docs-site-ui/src/css/typeface-roboto-mono.css
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: SUSE LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 @font-face {
   font-family: "Roboto Mono";
   font-style: normal;

--- a/trento-docs-site-ui/src/css/typeface-roboto.css
+++ b/trento-docs-site-ui/src/css/typeface-roboto.css
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: SUSE LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 @font-face {
   font-family: "Roboto";
   font-style: normal;

--- a/trento-docs-site-ui/src/css/vars.css
+++ b/trento-docs-site-ui/src/css/vars.css
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: SUSE LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 :root {
   /* colors */
   --color-white: #fff;

--- a/trento-docs-site-ui/src/helpers/and.js
+++ b/trento-docs-site-ui/src/helpers/and.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 'use strict'
 
 module.exports = (...args) => {

--- a/trento-docs-site-ui/src/helpers/detag.js
+++ b/trento-docs-site-ui/src/helpers/detag.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 'use strict'
 
 const TAG_ALL_RX = /<[^>]+>/g

--- a/trento-docs-site-ui/src/helpers/eq.js
+++ b/trento-docs-site-ui/src/helpers/eq.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 'use strict'
 
 module.exports = (a, b) => a === b

--- a/trento-docs-site-ui/src/helpers/increment.js
+++ b/trento-docs-site-ui/src/helpers/increment.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 'use strict'
 
 module.exports = (value) => (value || 0) + 1

--- a/trento-docs-site-ui/src/helpers/ne.js
+++ b/trento-docs-site-ui/src/helpers/ne.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 'use strict'
 
 module.exports = (a, b) => a !== b

--- a/trento-docs-site-ui/src/helpers/not.js
+++ b/trento-docs-site-ui/src/helpers/not.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 'use strict'
 
 module.exports = (val) => !val

--- a/trento-docs-site-ui/src/helpers/or.js
+++ b/trento-docs-site-ui/src/helpers/or.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 'use strict'
 
 module.exports = (...args) => {

--- a/trento-docs-site-ui/src/helpers/relativize.js
+++ b/trento-docs-site-ui/src/helpers/relativize.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 'use strict'
 
 const { posix: path } = require('path')

--- a/trento-docs-site-ui/src/helpers/year.js
+++ b/trento-docs-site-ui/src/helpers/year.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 'use strict'
 
 module.exports = () => new Date().getFullYear().toString()

--- a/trento-docs-site-ui/src/js/01-nav.js
+++ b/trento-docs-site-ui/src/js/01-nav.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 ;(function () {
   'use strict'
 

--- a/trento-docs-site-ui/src/js/02-on-this-page.js
+++ b/trento-docs-site-ui/src/js/02-on-this-page.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 ;(function () {
   'use strict'
 

--- a/trento-docs-site-ui/src/js/03-fragment-jumper.js
+++ b/trento-docs-site-ui/src/js/03-fragment-jumper.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 ;(function () {
   'use strict'
 

--- a/trento-docs-site-ui/src/js/04-page-versions.js
+++ b/trento-docs-site-ui/src/js/04-page-versions.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 ;(function () {
   'use strict'
 

--- a/trento-docs-site-ui/src/js/05-mobile-navbar.js
+++ b/trento-docs-site-ui/src/js/05-mobile-navbar.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 ;(function () {
   'use strict'
 

--- a/trento-docs-site-ui/src/js/06-copy-to-clipboard.js
+++ b/trento-docs-site-ui/src/js/06-copy-to-clipboard.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 ;(function () {
   'use strict'
 

--- a/trento-docs-site-ui/src/js/vendor/highlight.bundle.js
+++ b/trento-docs-site-ui/src/js/vendor/highlight.bundle.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 ;(function () {
   'use strict'
 

--- a/trento-docs-site/antora-playbook.yml
+++ b/trento-docs-site/antora-playbook.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 site:
   title: Trento Documentation
   url: https://trento-project.github.io/docs

--- a/trento-docs-site/antora.yml
+++ b/trento-docs-site/antora.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 name: ROOT
 title: Trento Documentation
 version: ~

--- a/trento-docs-site/extensions/edit-url.cjs
+++ b/trento-docs-site/extensions/edit-url.cjs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 "use strict";
 const fs = require("node:fs");
 const path = require("node:path");

--- a/trento-docs-site/extensions/edit-url.test.cjs
+++ b/trento-docs-site/extensions/edit-url.test.cjs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 "use strict";
 
 const fs = require("node:fs");

--- a/trento-docs-site/jest.config.cjs
+++ b/trento-docs-site/jest.config.cjs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 'use strict'
 
 module.exports = {

--- a/trento-docs-site/scripts/generate-attributes-yaml.sh
+++ b/trento-docs-site/scripts/generate-attributes-yaml.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+
 # Accepts generic-attributes.adoc from doc-unversioned and generates antora.yml with asciidoc attributes
 INPUT_FILE="$1"
 OUTPUT_FILE="$2"
@@ -33,7 +37,7 @@ declare -A seen
 # Read all keys from generic-attributes.adoc
 grep '^:' "$INPUT_FILE" | while read -r line; do
   key=$(echo "$line" | sed -E 's/^:([^:]+):.*/\1/' | xargs)
-  
+
   # skip key if seen or in ignore list
   if [[ -n "${seen[$key]}" ]] || is_ignored "$key"; then
     continue

--- a/trento-docs-site/scripts/generate-components.nav.js
+++ b/trento-docs-site/scripts/generate-components.nav.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import path from "path";
 import { promises as fs } from "fs";
 const CONFIG = {


### PR DESCRIPTION
# Description

In an attempt to follow the REUSE Specification (supported by the Linux Foundation) for managing licence information, this PR adds the recommended `SPDX-FileCopyrightText` and `SPDX-License-Identifier` headers.

Besides, a new linter is added for the CI to check the license headers. 

Related # TRNT-4358

## How was this tested?

License linter.