### PR TITLE
Ansible support

### DIFF
--- a/trento/adoc/trento-ansible-install.adoc
+++ b/trento/adoc/trento-ansible-install.adoc
@@ -112,6 +112,11 @@ Third-party dependencies:
 `{nginx}`::
   HTTP server used as reverse proxy.
 
+Diagnostics tooling:
+
+`supportutils`::
+  Installs the {suse} `supportutils` package and the Trento-specific `supportutils-plugin-trento` plugin on {trserver} and {tragent} hosts, so that `supportconfig` can collect Trento diagnostics.
+
 The `ansible-trento` package provides an {ansible} role for every one of these components.
 
 ==== Playbooks overview
@@ -300,6 +305,50 @@ For {tragent}, they are:
 
 The rest of the variables are optional.
 You can find the full listing on the https://github.com/trento-project/ansible[{trento} {ansible}] project page.
+
+==== Support tooling
+
+The `server`, `agent`, and `site` playbooks install the {suse} `supportutils` package together with the Trento-specific `supportutils-plugin-trento` plugin.
+This allows `supportconfig` to collect Trento diagnostics on both {trserver} and {tragent} hosts.
+The installation is performed by the `supportutils` role and is enabled by default; no additional opt-in is required.
+
+===== Configuration
+
+Override the following role-level variables in your inventory to change the default behavior:
+
+[width="100%",cols="35%,30%,35%",options="header",]
+|===
+|Name |Default |Description
+| `supportutils_enabled` | `true` | Set to `false` to skip installation entirely.
+| `supportutils_package_name` | `supportutils` | Base {suse} diagnostics package name.
+| `supportutils_plugin_package_name` | `supportutils-plugin-trento` | Trento plugin package name.
+| `supportutils_update_cache` | `true` | Refresh the {zypper} cache before installing.
+|===
+
+To disable installation on all hosts, set the variable in the `vars:` section of your inventory:
+
+[source,yaml]
+----
+all:
+  vars:
+    supportutils_enabled: false
+----
+
+===== Generating a support archive
+
+After the playbook runs, generate a support archive on any installed host with:
+
+[source,console,subs="attributes"]
+----
+{prompt_sudo} supportconfig
+----
+
+The resulting tarball includes the Trento-specific data collected by the plugin and can be attached to {suse} support cases.
+
+===== Cleanup behavior
+
+The `cleanup` playbook removes only the `supportutils-plugin-trento` package from {trserver} and {tragent} hosts.
+The base `supportutils` package is intentionally retained, because it is general-purpose {suse} tooling that other diagnostic workflows may rely on.
 
 ==== Example scenarios
 

--- a/trento/adoc/trento-ansible-install.adoc
+++ b/trento/adoc/trento-ansible-install.adoc
@@ -2,7 +2,7 @@ include::product-attributes.adoc[]
 
 [[sec-ansible-deployment]]
 === Automated Installation with {ansible}
-:revdate: 2026-03-20
+:revdate: 2026-05-12
 
 You can perform an automated installation of {trento} using RPM packages with {ansible} playbooks provided by the `ansible-trento` package.
 


### PR DESCRIPTION
# Description
The server, agent, and site playbooks now install supportutils + supportutils-plugin-trento by default on SLES for SAP 15 SP5+, so supportconfig archives include Trento diagnostics. 
This change brings the docs in line with that behavior.
## Changes
- Document the new `supportutils` Ansible role introduced in trento-project/ansible#106
- Add a `Diagnostics tooling` entry under **Components** describing the role
- Add a new **Support tooling** subsection covering configuration variables

