### PR TITLE
Visualization of versions of different components in About view

### DIFF
--- a/trento/adoc/trento-web-console.adoc
+++ b/trento/adoc/trento-web-console.adoc
@@ -19,9 +19,7 @@ perform on the different targets (hosts or clusters), cluster types
 (HANA scale up, HANA scale out or ASCS/ERS) and supported platforms
 (Azure, AWS, GCP, Nutanix, on-premises/KVM or VMware).
 * *Settings* Allows you to modify user-defined settings.
-* *About* Shows the versions of the different components of Trento Server, a link to the GitHub repository of the
-{trento} Web component, and the number of registered
-{sles4sap}{nbsp}subscriptions that has been discovered.
+* *About* Shows the versions of the different components of {trserver}, a link to the GitHub repository of the {tr_web} component, and the number of registered {sles4sap}{nbsp}subscriptions that have been discovered.
 
 [[sec-trento-health]]
 === Getting the global health state

--- a/trento/adoc/trento-web-console.adoc
+++ b/trento/adoc/trento-web-console.adoc
@@ -19,7 +19,7 @@ perform on the different targets (hosts or clusters), cluster types
 (HANA scale up, HANA scale out or ASCS/ERS) and supported platforms
 (Azure, AWS, GCP, Nutanix, on-premises/KVM or VMware).
 * *Settings* Allows you to modify user-defined settings.
-* *About* Shows the current server version, a link to the GitHub repository of the
+* *About* Shows the versions of the different components of Trento Server, a link to the GitHub repository of the
 {trento} Web component, and the number of registered
 {sles4sap}{nbsp}subscriptions that has been discovered.
 


### PR DESCRIPTION
The About view now shows the versions of all components of Trento Server, not only web.