### PR TITLE
Updates on helm deployments procedures regarding the write endopoint

### DIFF
--- a/trento/adoc/trento-integration-prometheus.adoc
+++ b/trento/adoc/trento-integration-prometheus.adoc
@@ -1,6 +1,7 @@
 include::product-attributes.adoc[]
 
 :revdate: 2026-04-30
+[[sec-prometheus-integration]]
 == {prometheus} integration
 
 {prometheus} Server is a {trserver} component responsible for retrieving host metrics from the agent hosts and serving them to the web component. The web component renders some of these metrics as graphical charts in the details view of the registered hosts. Particularly: memory, CPU, filesystem and swap utilization.
@@ -38,9 +39,9 @@ See <<configuring-alloy>> for detailed setup instructions.
 
 === {kube} deployment
 
-When using the {helm} chart to deploy {trserver} on a {kube} cluster, an image of {prometheus} Server is deployed automatically. No further actions are required by the user, other than ensuring that it can reach the `node-exporter` in the agent hosts.
+To enable {prometheus} alongside {trserver} in a {k8s} cluster, see <<enabling-remote-write>>.
 
-In a {kube} cluster with multiple nodes, the user can select on which node to deploy the {prometheus} Server by adding the following flag to the {helm} installation command:
+In a {kube} cluster with multiple nodes, the user can select on which node to deploy {prometheus} Server by adding the following flag to the {helm} installation command:
 
 [source,bash]
 ----
@@ -156,10 +157,12 @@ The {helm} chart enables the {prometheus} remote write receiver and deploys an {
 
 The {nginx} sidecar protects the `/prometheus/api/v1/write` endpoint with HTTP Basic Auth. Other {prometheus} routes (UI and query API) remain accessible without authentication.
 
-To enable basic authentication, add the following values to your {helm} installation:
+To enable {prometheus} with basic authentication, replace flag `--set prometheus.enabled=false` in the 
+{helm} installation command with the following:
 
 [source,bash]
 ----
+--set prometheus.enabled=true \
 --set prometheus.server.auth.type=basic \
 --set prometheus.server.auth.basic.username=<username> \
 --set prometheus.server.auth.basic.password=<password>

--- a/trento/adoc/trento-kubernetes-install.adoc
+++ b/trento/adoc/trento-kubernetes-install.adoc
@@ -69,19 +69,6 @@ helm upgrade \
 ----
 ====
 +
-When using a Helm version lower than 3.8.0, an experimental flag must be set as follows:
-+
-====
-[source,bash]
-----
-HELM_EXPERIMENTAL_OCI=1 helm upgrade \
-   --install trento-server oci://registry.suse.com/trento/trento-server \
-   --set global.trentoWeb.origin=TRENTO_SERVER_HOSTNAME \
-   --set trento-web.adminUser.password=ADMIN_PASSWORD \
-   --set prometheus.enabled=false
-----
-====
-+
 . To verify that the {trserver} installation was successful, open the URL of the {tr_web} (`http://TRENTO_SERVER_HOSTNAME`) from a workstation on the {sap} administrator's LAN.
 
 [[sec-trento-install-trentoserver-on-k3s]]
@@ -149,18 +136,6 @@ helm upgrade \
    --set prometheus.enabled=false
 ----
 ====
-When using a Helm version lower than 3.8.0, an experimental flag must be set as follows:
-+
-====
-[source,bash]
-----
-HELM_EXPERIMENTAL_OCI=1 helm upgrade \
-   --install trento-server oci://registry.suse.com/trento/trento-server \
-   --set global.trentoWeb.origin=TRENTO_SERVER_HOSTNAME \
-   --set trento-web.adminUser.password=ADMIN_PASSWORD \
-   --set prometheus.enabled=false
-----
-====
 +
 . Monitor the creation and start-up of the {trserver} pods, and wait until they are ready and running:
 +
@@ -183,13 +158,12 @@ If you use a multi-node {k8s} cluster, it is possible to deploy {trserver} image
 ====
 [source,bash]
 ----
-HELM_EXPERIMENTAL_OCI=1 helm upgrade \
+ helm upgrade \
    --install trento-server oci://registry.suse.com/trento/trento-server \
    --set global.trentoWeb.origin=TRENTO_SERVER_HOSTNAME \
    --set trento-web.adminUser.password=ADMIN_PASSWORD \
    --set postgresql.primary.nodeSelector.LABEL=VALUE \
    --set trento-web.nodeSelector.LABEL=VALUE \
-   --set trento-runner.nodeSelector.LABEL=VALUE \
    --set prometheus.enabled=false
 ----
 ====
@@ -275,7 +249,7 @@ The command to enable email alerts is as follows:
 
 [source,bash]
 ----
-HELM_EXPERIMENTAL_OCI=1 helm upgrade \
+helm upgrade \
    --install trento-server oci://registry.suse.com/trento/trento-server \
    --set global.trentoWeb.origin=TRENTO_SERVER_HOSTNAME \
    --set trento-web.adminUser.password=ADMIN_PASSWORD \

--- a/trento/adoc/trento-kubernetes-install.adoc
+++ b/trento/adoc/trento-kubernetes-install.adoc
@@ -35,9 +35,15 @@ kubectl create namespace trento
 helm upgrade \
    --install trento-server oci://registry.suse.com/trento/trento-server \
    --namespace trento \
-   --set global.trentoWeb.origin=TRENTO_SERVER_HOSTNAME \
-   --set trento-web.adminUser.password=ADMIN_PASSWORD
+   ...
+
 ----
+====
+
+[NOTE]
+====
+The examples in this section deliver an installation of {trserver} without {prometheus}. If you want to have {prometheus}
+installed and enabled along {trserver} refer to <<sec-prometheus-integration>>.
 ====
 
 . Install Helm:
@@ -58,7 +64,8 @@ curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bas
 helm upgrade \
    --install trento-server oci://registry.suse.com/trento/trento-server \
    --set global.trentoWeb.origin=TRENTO_SERVER_HOSTNAME \
-   --set trento-web.adminUser.password=ADMIN_PASSWORD
+   --set trento-web.adminUser.password=ADMIN_PASSWORD \
+   --set prometheus.enabled=false
 ----
 ====
 +
@@ -70,7 +77,8 @@ When using a Helm version lower than 3.8.0, an experimental flag must be set as 
 HELM_EXPERIMENTAL_OCI=1 helm upgrade \
    --install trento-server oci://registry.suse.com/trento/trento-server \
    --set global.trentoWeb.origin=TRENTO_SERVER_HOSTNAME \
-   --set trento-web.adminUser.password=ADMIN_PASSWORD
+   --set trento-web.adminUser.password=ADMIN_PASSWORD \
+   --set prometheus.enabled=false
 ----
 ====
 +
@@ -79,15 +87,12 @@ HELM_EXPERIMENTAL_OCI=1 helm upgrade \
 [[sec-trento-install-trentoserver-on-k3s]]
 ===== Installing {trserver} on K3s
 
-If you do not have a {k8s} cluster, or you have one but you do not want to use it for {trento}, you can use {suse} Rancher's K3s as an alternative. To deploy {trserver} on K3s, you need a server or VM (see <<sec-trento-server-requirements>> for minimum requirements) and follow steps in <<pro-trento-manually-installing>>.
+If you do not have a {k8s} cluster, or you have one but you do not want to use it for {trento}, you can use {suse} Rancher's K3s as an alternative. To deploy {trserver} on K3s, you need a server or VM (see <<sec-trento-server-requirements>> for minimum requirements) and follow the steps in the following procedure.
 
 [IMPORTANT]
 ====
 The following procedure deploys {trserver} on a single-node K3s cluster. Note that this setup is not recommended for production use.
 ====
-
-[[pro-trento-manually-installing]]
-====== Manually installing Trento on a {trserver} host
 
 . Log in to the {trserver} host.
 +
@@ -140,7 +145,8 @@ export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 helm upgrade \
    --install trento-server oci://registry.suse.com/trento/trento-server \
    --set global.trentoWeb.origin=TRENTO_SERVER_HOSTNAME \
-   --set trento-web.adminUser.password=ADMIN_PASSWORD
+   --set trento-web.adminUser.password=ADMIN_PASSWORD \
+   --set prometheus.enabled=false
 ----
 ====
 When using a Helm version lower than 3.8.0, an experimental flag must be set as follows:
@@ -151,7 +157,8 @@ When using a Helm version lower than 3.8.0, an experimental flag must be set as 
 HELM_EXPERIMENTAL_OCI=1 helm upgrade \
    --install trento-server oci://registry.suse.com/trento/trento-server \
    --set global.trentoWeb.origin=TRENTO_SERVER_HOSTNAME \
-   --set trento-web.adminUser.password=ADMIN_PASSWORD
+   --set trento-web.adminUser.password=ADMIN_PASSWORD \
+   --set prometheus.enabled=false
 ----
 ====
 +
@@ -180,10 +187,10 @@ HELM_EXPERIMENTAL_OCI=1 helm upgrade \
    --install trento-server oci://registry.suse.com/trento/trento-server \
    --set global.trentoWeb.origin=TRENTO_SERVER_HOSTNAME \
    --set trento-web.adminUser.password=ADMIN_PASSWORD \
-   --set prometheus.server.nodeSelector.LABEL=VALUE \
    --set postgresql.primary.nodeSelector.LABEL=VALUE \
    --set trento-web.nodeSelector.LABEL=VALUE \
-   --set trento-runner.nodeSelector.LABEL=VALUE
+   --set trento-runner.nodeSelector.LABEL=VALUE \
+   --set prometheus.enabled=false
 ----
 ====
 
@@ -227,6 +234,7 @@ helm upgrade \
   --install trento-server oci://registry.suse.com/trento/trento-server \
   --set global.trentoWeb.origin=TRENTO_SERVER_HOSTNAME \
   --set trento-web.adminUser.password=ADMIN_PASSWORD \
+  --set prometheus.enabled=false \
   --set trento-web.pruneEventsOlderThan=30 \
   --set trento-web.pruneEventsCronjobSchedule="0 3 * * *"
 ----
@@ -271,6 +279,7 @@ HELM_EXPERIMENTAL_OCI=1 helm upgrade \
    --install trento-server oci://registry.suse.com/trento/trento-server \
    --set global.trentoWeb.origin=TRENTO_SERVER_HOSTNAME \
    --set trento-web.adminUser.password=ADMIN_PASSWORD \
+   --set prometheus.enabled=false \
    --set trento-web.alerting.enabled=true \
    --set trento-web.alerting.smtpServer=SMTP_SERVER \
    --set trento-web.alerting.smtpPort=SMTP_PORT \

--- a/trento/adoc/trento-sso-integration.adoc
+++ b/trento/adoc/trento-sso-integration.adoc
@@ -52,7 +52,7 @@ To enable OIDC when using kubernetes deployment with helm, add the following var
 ====
 [source,bash]
 ----
-HELM_EXPERIMENTAL_OCI=1 helm ... \
+helm ... \
    --set trento-web.oidc.enabled=true \
    --set trento-web.oidc.clientId=<OIDC_CLIENT_ID> \
    --set trento-web.oidc.clientSecret=<OIDC_CLIENT_SECRET> \
@@ -127,7 +127,7 @@ installation command:
 ====
 [source,bash]
 ----
-HELM_EXPERIMENTAL_OCI=1 helm ... \
+helm ... \
    --set trento-web.oauth2.enabled=true \
    --set trento-web.oauth2.clientId=<OAUTH2_CLIENT_ID> \
    --set trento-web.oauth2.clientSecret=<OAUTH2_CLIENT_SECRET> \
@@ -143,7 +143,7 @@ Additionally, the following optional values are available:
 ====
 [source,bash]
 ----
-HELM_EXPERIMENTAL_OCI=1 helm ... \
+helm ... \
    --set trento-web.oauth2.scopes=<OAUTH2_SCOPES>
 ----
 ====
@@ -337,7 +337,7 @@ installation command:
 ====
 [source,bash]
 ----
-HELM_EXPERIMENTAL_OCI=1 helm ... \
+helm ... \
    --set trento-web.saml.enabled=true \
    --set trento-web.saml.idpId=<SAML_IDP_ID> \
    --set trento-web.saml.spId=<SAML_SP_ID> \
@@ -351,7 +351,7 @@ To use the `+SAML_METADATA_CONTENT+` option rather than
 ====
 [source,bash]
 ----
-HELM_EXPERIMENTAL_OCI=1 helm ... \
+helm ... \
    --set trento-web.saml.enabled=true \
    --set trento-web.saml.idpId=<SAML_IDP_ID> \
    --set trento-web.saml.spId=<SAML_SP_ID> \
@@ -364,7 +364,7 @@ Additionally, the following optional values are available:
 ====
 [source,bash]
 ----
-HELM_EXPERIMENTAL_OCI=1 helm ... \
+helm ... \
    --set trento-web.saml.idpNameIdFormat=<SAML_IDP_NAMEID_FORMAT> \
    --set trento-web.saml.spDir=<SAML_SP_DIR> \
    --set trento-web.saml.spEntityId=<SAML_SP_ENTITY_ID> \

--- a/trento/adoc/trento-update-trento-server.adoc
+++ b/trento/adoc/trento-update-trento-server.adoc
@@ -33,8 +33,7 @@ helm upgrade \
 
 If you have configured/enabled options, the {helm} command must be adjusted accordingly. In this case, consider the following:
 
-* Remember to set the helm experimental flag if you are using a version
-of Helm lower than 3.8.0.
+* If you are using a version of Helm lower than 3.8.0, you need to set `HELM_EXPERIMENTAL_OCI=1` in front of the `helm` command.
 * When updating {trento} to version 2.0.0 or higher, an additional flag
 must be set in the Helm command:
 +

--- a/trento/adoc/trento-update-trento-server.adoc
+++ b/trento/adoc/trento-update-trento-server.adoc
@@ -25,13 +25,13 @@ In a {k8s} deployment, you can use Helm to update {trserver}:
 helm upgrade \
    --install trento-server oci://registry.suse.com/trento/trento-server \
    --set global.trentoWeb.origin=TRENTO_SERVER_HOSTNAME \
-   --set trento-web.adminUser.password=ADMIN_PASSWORD
+   --set trento-web.adminUser.password=ADMIN_PASSWORD \
+   ...
         
 ----
 ====
 
-If you have configured options like email alerting, the Helm command
-must be adjusted accordingly. In this case, consider the following:
+If you have configured/enabled options, the {helm} command must be adjusted accordingly. In this case, consider the following:
 
 * Remember to set the helm experimental flag if you are using a version
 of Helm lower than 3.8.0.
@@ -53,6 +53,7 @@ helm upgrade \
 * When updating {trento} to version 2.3 or higher, a new API key is
 generated and the configuration of all registered {tragent}s must be
 updated accordingly.
+* When updating to version 3.1 or higher, {prometheus} authentication must be configured.
 
 In a system deployment, you can use zypper to update {trserver}:
 


### PR DESCRIPTION
See https://jira.suse.com/browse/TRNT-4424.

- Section https://documentation.suse.com/sles-sap/trento/html/SLES-SAP-trento/id-installation.html#sec-trento-k8s-deployment:
-- Add the following flags to all the helm installation commands included in the section: --set prometheus.enabled=false 
-- Add note explaining that this delivers an installation of Trento Server with no prometheus
- Section https://documentation.suse.com/sles-sap/trento/html/SLES-SAP-trento/id-prometheus-integration.html#id-kubernetes-deployment:
-- Re-write the section explaining that when prometheus is enabled in a K8s installation, the write end point is enabled by default and therefore it requires specifying what type of authentication we want to use and, in case of basic authentication, also the username and password. The refer the user to the section where it is explained how to the "Enabling Prometheus remote write for Grafana Alloy hosts" for further details.
- Section https://documentation.suse.com/sles-sap/trento/html/SLES-SAP-trento/id-update.html#sec-trento-updating-trentoserver:
-- explain that when updating to 3.1 in a helm installation, prometheus authentication type must be specified and, in the case of basic, username and password must be provided.