### PR TITLE
Fix documentation links

### DIFF
--- a/trento/adoc/trento-kubernetes-install.adoc
+++ b/trento/adoc/trento-kubernetes-install.adoc
@@ -69,7 +69,7 @@ helm upgrade \
 ----
 ====
 +
-. To verify that the {trserver} installation was successful, open the URL of the {tr_web} (`http://TRENTO_SERVER_HOSTNAME`) from a workstation on the {sap} administrator's LAN.
+. To verify that the {trserver} installation was successful, open the URL of the {tr_web} (`\http://TRENTO_SERVER_HOSTNAME`) from a workstation on the {sap} administrator's LAN.
 
 [[sec-trento-install-trentoserver-on-k3s]]
 ===== Installing {trserver} on K3s
@@ -149,7 +149,7 @@ watch kubectl get pods
 All pods must be in the ready and running state.
 +
 . Log out of the {trserver} host.
-. To verify that the {trserver} installation was successful, open the URL of the {tr_web} (`http://TRENTO_SERVER_HOSTNAME`) from a workstation on the {sap} administrator's LAN.
+. To verify that the {trserver} installation was successful, open the URL of the {tr_web} (`\http://TRENTO_SERVER_HOSTNAME`) from a workstation on the {sap} administrator's LAN.
 
 [[sec-trento-deploying-trento-on-selected-nodes]]
 ===== Deploying {trserver} on selected nodes

--- a/trento/adoc/trento-mcp-host-others.adoc
+++ b/trento/adoc/trento-mcp-host-others.adoc
@@ -76,7 +76,7 @@ When using this option, ensure your configuration file has appropriate permissio
 
 [NOTE]
 ====
-Replace `{tr_mcp_url_https}` with your actual {tr_mcp} endpoint URL from your installation.
+Replace `pass:a[{tr_mcp_url_https}]` with your actual {tr_mcp} endpoint URL from your installation.
 ====
 
 ====== Client options

--- a/trento/adoc/trento-mcp-host-sles.adoc
+++ b/trento/adoc/trento-mcp-host-sles.adoc
@@ -46,9 +46,9 @@ mcpServers:
       - "Authorization: Bearer ${env://TRENTO_PAT}"
 ----
 
-* Replace `{tr_mcp_url_https}` with the actual URL where your {tr_mcp} is accessible:
-  ** For Kubernetes deployments with ingress, use the ingress URL (e.g., `{tr_mcp_url_https}`).
-  ** For local or development setups, use `http://localhost:{tr_mcp_default_port}/mcp` (adjust the port as needed).
+* Replace `pass:a[{tr_mcp_url_https}]` with the actual URL where your {tr_mcp} is accessible:
+  ** For Kubernetes deployments with ingress, use the ingress URL (e.g., `pass:a[{tr_mcp_url_https}]`).
+  ** For local or development setups, use `\http://localhost:{tr_mcp_default_port}/mcp` (adjust the port as needed).
   ** The transport type is configured on the {tr_mcp}, if using Server-Sent Events (SSE) transport instead of the default streamable transport, change the path from `/mcp` to `/sse`.
 * If you configured a custom header name (using `HEADER_NAME` or `--header-name`), update `Authorization` accordingly.
 
@@ -132,7 +132,7 @@ If you encounter issues connecting {mcp_host} to the {tr_mcp}:
 ** Verify that the {tr_mcp} URL in `~/.mcphost.yml` is correct and accessible from your system.
 ** Check if the {tr_mcp} is running by reviewing logs from your {trento} installation.
 ** Ensure network connectivity and that any required firewall rules are in place.
-** Test basic connectivity: `curl -I {tr_mcp_url_https}`.
+** Test basic connectivity: `curl -I pass:a[{tr_mcp_url_https}]`.
 
 * *Authentication errors*
 ** Verify that your personal access token is valid by testing it directly with your {trento} Server API.

--- a/trento/adoc/trento-mcp-install-kubernetes.adoc
+++ b/trento/adoc/trento-mcp-install-kubernetes.adoc
@@ -110,7 +110,7 @@ helm upgrade --install trento-server oci://registry.suse.com/trento/trento-serve
 ----
 ====
 
-The {tr_mcp} endpoint will be: `https://TRENTO_SERVER_HOSTNAME{tr_mcp_ingress_path}/mcp`
+The {tr_mcp} endpoint will be: `\https://TRENTO_SERVER_HOSTNAME{tr_mcp_ingress_path}/mcp`
 
 [[mcp-adjust-log-verbosity]]
 ====== Adjust Log Verbosity


### PR DESCRIPTION
### Description
Fixing in-line links to not render as clickable. 
For reference, you can check the html build, chapters `4 Installation` and `8 MCP Integration`
 For example:

Previously:
<img width="817" height="198" alt="image" src="https://github.com/user-attachments/assets/f6a2d7e6-4e0e-4fa3-83be-148dac65dabc" />

Now:
<img width="911" height="167" alt="image" src="https://github.com/user-attachments/assets/9e2cd0f2-d8f4-44bf-9eed-bfee80d32f45" />

### Reasoning
Rendering dummy links, such as `example.com`, unclickable is beneficial because it prevents automated documentation link checkers from attempting to validate a generic placeholder.

This change will go to `latest` as well.


