### PR TITLE
Add information about updating CA certificates on Trento Server host

### DIFF
--- a/trento/adoc/trento-integration-prometheus.adoc
+++ b/trento/adoc/trento-integration-prometheus.adoc
@@ -1,6 +1,6 @@
 include::product-attributes.adoc[]
 
-:revdate: 2026-04-30
+:revdate: 2026-06-11
 [[sec-prometheus-integration]]
 == {prometheus} integration
 

--- a/trento/adoc/trento-systemd-install.adoc
+++ b/trento/adoc/trento-systemd-install.adoc
@@ -2,7 +2,7 @@ include::product-attributes.adoc[]
 
 [[sec-systemd-deployment]]
 ==== systemd deployment
-:revdate: 2025-06-11
+:revdate: 2026-06-19
 
 A systemd-based installation of the {trserver} using RPM packages can be performed manually on the latest supported versions of {sles4sap}, from 15 SP4 up to 16. For installations on service packs other than the current one, make sure to update the repository URL as described in the relevant notes throughout this guide.
 

--- a/trento/adoc/trento-systemd-install.adoc
+++ b/trento/adoc/trento-systemd-install.adoc
@@ -509,6 +509,11 @@ mkdir -p /etc/nginx/ssl/certs/
 ----
 cp trento.crt /etc/nginx/ssl/certs/trento.crt
 ----
++
+[IMPORTANT]
+====
+Update the CA certificates on the {trserver} host to ensure the self-signed certificate is trusted.
+====
 . Check the NGINX configuration:
 +
 [source,bash]
@@ -526,7 +531,6 @@ nginx: configuration file /etc/nginx/nginx.conf test is successful
 +
 If there are issues with the configuration, the output indicates what
 needs to be adjusted.
-+
 . Enable NGINX:
 +
 [source,bash]

--- a/trento/adoc/trento-systemd-install.adoc
+++ b/trento/adoc/trento-systemd-install.adoc
@@ -509,11 +509,30 @@ mkdir -p /etc/nginx/ssl/certs/
 ----
 cp trento.crt /etc/nginx/ssl/certs/trento.crt
 ----
+
+. Ensure the self-signed certificate is trusted:
+
+.. Convert `trento.crt` to the PEM format:
 +
-[IMPORTANT]
-====
-Update the CA certificates on the {trserver} host to ensure the self-signed certificate is trusted.
-====
+[source,bash]
+----
+openssl x509 -in trento.crt -out trento.pem -outform PEM
+----
+
+.. Copy the certificate in PEM format to `/etc/pki/trust/anchors/`:
++
+[source,bash]
+----
+cp trento.pem /etc/pki/trust/anchors/
+----
+
+.. Run the `update-ca-certificates` command:
++
+[source,bash]
+----
+update-ca-certificates
+----
+
 . Check the NGINX configuration:
 +
 [source,bash]


### PR DESCRIPTION
### Description

Add missing information about updating CA certificates.
Fixes [TRNT-4398](https://jira.suse.com/browse/TRNT-4398)
<!-- Optionally use depends #<issue> for dependent PRs -->

#### Branches:
`main`, `latest`

**NOTE TO MYSELF BEFORE MERGING:** need to update revision history for this and for https://github.com/trento-project/docs/pull/210