### PR TITLE
Update cluster discovery prerequisites

### DIFF
--- a/trento/adoc/trento-requirements.adoc
+++ b/trento/adoc/trento-requirements.adoc
@@ -2,7 +2,7 @@ include::product-attributes.adoc[]
 
 [[sec-trento-requirements]]
 == Requirements
-:revdate: 2026-01-08
+:revdate: 2026-06-19
 
 This section describes requirements for the {trserver} and its {tragent}s, as well as the {sap} systems and clusters that we want to monitor in the backend environment.
 
@@ -16,8 +16,8 @@ Running all the {trserver} components requires a minimum of 4 GB of RAM, two CPU
 {trserver} supports different deployment scenarios: {k8s} and systemd. A {k8s}-based deployment of {trserver} is cloud-native and OS-agnostic. It can be performed on the following services:
 
 * RKE2
-* a {k8s} service in a cloud provider
-* any other CNCF-certified {k8s} running on x86_64 architecture
+* A {k8s} service in a cloud provider
+* Any other CNCF-certified {k8s} running on x86_64 architecture
 
 The Helm chart and the container images required for a {k8s}-based deployment are available in {suse} public registry.
 
@@ -32,24 +32,25 @@ The resource footprint of the {tragent} is designed to not impact the performanc
 
 The {tragent} component needs to interact with several low-level system components that are part of the {sles4sap} distribution.
 
-The hosts must have unique machine identifiers (ids) in order to be registered in Trento. This means that if a host in your environment is built as a clone of another one, make sure to change the machine's identifier as part of the cloning process before starting the {tragent} on it.
+The hosts must have unique machine identifiers (ids) to be registered in {trento}. This means that if a host in your environment is built as a clone of another one, make sure to change the machine's identifier as part of the cloning process before starting the {tragent} on it.
 
-Similarly, the clusters must have unique authkeys in order to be registered in {trento}.
+Similarly, the clusters must have unique authkeys to be registered in {trento}.
 
 The {tragent} package is available in the repositories of {sles4sap} 15 (SP4 or higher) or {sles4sap} 16.0.
 
 [[sec-trento-network-requirements]]
 === Network requirements
 
-* Required inbound connectivity:
-** From any {tragent} host to {trserver} at port TCP/80 (HTTP), or TCP/443 (HTTPS) if SSL is enabled.
-** From any {tragent} host to {trserver} at port TCP/5672 (Advanced Message Queuing Protocol or AMQP)
-** From the user network to {trserver} at port TCP/80 (HTTP), or TCP/443 (HTTPS) if SSL is enabled.
-** If the {tr_mcp} is installed and enabled:
-*** For a {k8s} deployment, from the MCP client to the {trserver} ingress at TCP/80 or TCP/443. Internally, the MCP Server Pod uses TCP/{tr_mcp_default_port} and TCP/8080 if the health check is enabled.
-*** For a systemd deployment, from the user network to {tr_mcp} at TCP/{tr_mcp_default_port}.
-** Optionally: From the user network to {trserver} at ports TCP/4000, TCP/4001 and TCP/8080 (health checks for web, wanda and MCP, respectively).
-** From Prometheus server, when it exists, to each {tragent} host at the port used by the Node Exporter.
+Required inbound connectivity:
+
+* From any {tragent} host to {trserver} at port TCP/80 (HTTP), or TCP/443 (HTTPS) if SSL is enabled.
+* From any {tragent} host to {trserver} at port TCP/5672 (Advanced Message Queuing Protocol or AMQP)
+* From the user network to {trserver} at port TCP/80 (HTTP), or TCP/443 (HTTPS) if SSL is enabled.
+* If the {tr_mcp} is installed and enabled:
+** For a {k8s} deployment, from the MCP client to the {trserver} ingress at TCP/80 or TCP/443. Internally, the {mcp} Pod uses TCP/{tr_mcp_default_port} and TCP/8080 if the health check is enabled.
+** For a systemd deployment, from the user network to {tr_mcp} at TCP/{tr_mcp_default_port}.
+* Optionally: From the user network to {trserver} at ports TCP/4000, TCP/4001 and TCP/8080 (health checks for web, wanda and MCP, respectively).
+* From Prometheus server, when it exists, to each {tragent} host at the port used by the Node Exporter.
 
 [[sec-sap-requirements]]
 === {sap} requirements
@@ -58,13 +59,13 @@ An {sap} system must run on a HANA database to be discovered by {trento}. In add
 
 The agent must be installed in all the hosts that are part of the SAP system architecture. Particularly:
 
-* the host where the ASCS instance is running
-* the host where the ERS instance, if it exists, is running
-* all the hosts where an application server instance is running
-* all the database hosts
+* The host where the ASCS instance is running
+* The host where the ERS instance, if it exists, is running
+* All the hosts where an application server instance is running
+* All the database hosts
 
 [[sec-trento-cluster-requirements]]
 === Cluster requirements
 
-The initial discovery of a pacemaker cluster requires the DC node to be online. Once the cluster has been discovered, all nodes can be stopped and Trento will continue to discover the cluster. 
+The initial discovery of a {pace} cluster requires all cluster nodes to be online. After the cluster is discovered, all nodes can be stopped and {trento} continues to discover the cluster. 
 


### PR DESCRIPTION
### Description

* Replace `The initial discovery of a pacemaker cluster requires the DC node to be online. ` with
`The initial discovery of a pacemaker cluster requires all cluster nodes to be online.`

* Also fixing small docs bugs.

Fixes https://jira.suse.com/browse/TRNT-4212

### Screenshot of changes

<img width="1162" height="133" alt="image" src="https://github.com/user-attachments/assets/120df49a-138e-4bc9-9ccd-d52b74b58c86" />

PDF to see the additional small docs changes: 
[Requirements.pdf](https://github.com/user-attachments/files/29135911/User.Documentation.-.SLES-SAP-trento_en.pdf)


