### PR TITLE
Add information about trentoWeb.origin parameter

### DIFF
--- a/trento/adoc/trento-kubernetes-install.adoc
+++ b/trento/adoc/trento-kubernetes-install.adoc
@@ -2,7 +2,7 @@ include::product-attributes.adoc[]
 
 [[sec-trento-k8s-deployment]]
 ==== {k8s} deployment
-:revdate: 2026-07-09
+:revdate: 2026-07-10
 
 include::partials/kubernetes-placeholders.adoc[]
 
@@ -73,7 +73,7 @@ helm upgrade \
 Where:
 
 `global.trentoWeb.origin`::::
-Uses the provided hostname to configure internal functionalities such as the interactive API portal, websockets, or certificate generation.
+Uses the provided hostname (for example, `trento.example.com`) to configure internal functionalities such as the interactive API portal, websockets, or certificate generation.
 
 `trento-web.adminUser.password`::::
 Sets the initial password for the default admin account to access the {trento} console.
@@ -152,7 +152,7 @@ helm upgrade \
 Where:
 
 `global.trentoWeb.origin`::::
-Uses the provided hostname to configure internal functionalities such as the interactive API portal, websockets, or certificate generation.
+Uses the provided hostname (for example, `trento.example.com`) to configure internal functionalities such as the interactive API portal, websockets, or certificate generation.
 
 `trento-web.adminUser.password`::::
 Sets the initial password for the default admin account to access the {trento} console.

--- a/trento/adoc/trento-kubernetes-install.adoc
+++ b/trento/adoc/trento-kubernetes-install.adoc
@@ -2,7 +2,7 @@ include::product-attributes.adoc[]
 
 [[sec-trento-k8s-deployment]]
 ==== {k8s} deployment
-:revdate: 2026-01-08
+:revdate: 2026-07-09
 
 include::partials/kubernetes-placeholders.adoc[]
 
@@ -54,8 +54,9 @@ installed and enabled along {trserver} refer to <<sec-prometheus-integration>>.
 curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
 ----
 ====
-+
+
 . Connect Helm to an existing {k8s} cluster.
+
 . Use Helm to install {trserver} with the {trento} Helm chart:
 +
 ====
@@ -69,6 +70,17 @@ helm upgrade \
 ----
 ====
 +
+Where:
+
+`global.trentoWeb.origin`::::
+Uses the provided hostname to configure internal functionalities such as the interactive API portal, websockets, or certificate generation.
+
+`trento-web.adminUser.password`::::
+Sets the initial password for the default admin account to access the {trento} console.
+
+`prometheus.enabled`::::
+Enables or disables the deployment of Prometheus. For more information, see <<sec-prometheus-integration>>.
+
 . To verify that the {trserver} installation was successful, open the URL of the {tr_web} (`\http://TRENTO_SERVER_HOSTNAME`) from a workstation on the {sap} administrator's LAN.
 
 [[sec-trento-install-trentoserver-on-k3s]]
@@ -137,6 +149,17 @@ helm upgrade \
 ----
 ====
 +
+Where:
+
+`global.trentoWeb.origin`::::
+Uses the provided hostname to configure internal functionalities such as the interactive API portal, websockets, or certificate generation.
+
+`trento-web.adminUser.password`::::
+Sets the initial password for the default admin account to access the {trento} console.
+
+`prometheus.enabled`::::
+Enables or disables the deployment of Prometheus. For more information, see <<sec-prometheus-integration>>.
+
 . Monitor the creation and start-up of the {trserver} pods, and wait until they are ready and running:
 +
 ====
@@ -167,6 +190,8 @@ If you use a multi-node {k8s} cluster, it is possible to deploy {trserver} image
    --set prometheus.enabled=false
 ----
 ====
+
+Replace `LABEL` and `VALUE` with the actual label key and value of your target node.
 
 [[helm-event-pruning]]
 ===== Configuring event pruning

--- a/trento/adoc/trento-systemd-install.adoc
+++ b/trento/adoc/trento-systemd-install.adoc
@@ -2,7 +2,7 @@ include::product-attributes.adoc[]
 
 [[sec-systemd-deployment]]
 ==== systemd deployment
-:revdate: 2026-06-19
+:revdate: 2026-07-10
 
 A systemd-based installation of the {trserver} using RPM packages can be performed manually on the latest supported versions of {sles4sap}, from 15 SP4 up to 16. For installations on service packs other than the current one, make sure to update the repository URL as described in the relevant notes throughout this guide.
 
@@ -202,11 +202,6 @@ You can create the content of the secret variables such as
 ----
 openssl rand -out /dev/stdout 48 | base64
 ----
-
-Also ensure that a valid hostname, FQDN, or IP address is configured in
-`TRENTO_WEB_ORIGIN` when using HTTPS.
-Otherwise, WebSocket connections will fail, preventing real-time updates
-in the web interface.
 ====
 
 ====== trento-web configuration
@@ -233,16 +228,26 @@ OAS_SERVER_URL=https://trento.example.com
 ----
 ====
 
-The `ADMIN_PASSWORD` variable must must meet the following requiements:
+* The `TRENTO_WEB_ORIGIN` configures internal functionalities such as the interactive API portal, websockets, or certificate generation.
++
+[IMPORTANT]
+====
+Ensure that a valid hostname, FQDN, or IP address is configured in
+`TRENTO_WEB_ORIGIN` when using HTTPS.
+Otherwise, websocket connections will fail, preventing real-time updates
+in the web interface.
+====
+
+* The `ADMIN_PASSWORD` variable must meet the following requiements:
 	
-* minimum of 8 characters
-* the password  not contain 3 consecutive identical numbers or letters (for example, 111 or aaa)
-* the password must not contain 4 consecutive  numbers or letters (for example, 1234, abcd, ABCD)
+** Minimum of 8 characters
+** The password  not contain 3 consecutive identical numbers or letters (for example, 111 or aaa)
+** The password must not contain 4 consecutive  numbers or letters (for example, 1234, abcd, ABCD)
 
 
-The `ENABLE_ALERTING` enables the 
-https://www.trento-project.io/docs/web/Alerting/alerting.html[alerting system to receive email notifications]. Set `ENABLE_ALERTING` to `true` and add additional variables to the `/etc/trento/trento-web`, to enable the feature.
-
+* The `ENABLE_ALERTING` enables the 
+https://www.trento-project.io/docs/web/Alerting/alerting.html[alerting system to receive email notifications]. Set `ENABLE_ALERTING` to `true` and add additional variables to the `/etc/trento/trento-web`, to enable the feature:
++
 ====
 [source,bash]
 ----


### PR DESCRIPTION
### Description

Based on the thread in Slack, we could enhance the docs by adding some additional explanation for the  trentoWeb.origin parameter; I took the opportunity to add some additional small things.

Fixes https://jira.suse.com/browse/TRNT-4476
### Additional information

I have added it in two places, since both are separate user cases. Plus I added small extra explanation line to the "selected node" case.

Previews: 
[kubernetes installation - SLES-SAP-trento_en.pdf](https://github.com/user-attachments/files/29888153/kubernetes.installation.-.SLES-SAP-trento_en.pdf)

[RPM installation - SLES-SAP-trento_en.pdf](https://github.com/user-attachments/files/29888156/RPM.installation.-.SLES-SAP-trento_en.pdf)


<!-- Add anything else relevant to this PR, such as screenshots or demos. -->