### PR TITLE
Permissions on Trento configuration files + review and update installation with systemd steps

### DIFF
--- a/trento/adoc/trento-ansible-install.adoc
+++ b/trento/adoc/trento-ansible-install.adoc
@@ -64,7 +64,7 @@ Control node package requirements:
 +
 [source,console,subs="attributes"]
 ----
-{prompt_sudo} zypper install ansible
+{sudo} zypper install ansible
 ----
 
 Target node package requirements:
@@ -73,7 +73,7 @@ Target node package requirements:
 +
 [source,console,subs="attributes"]
 ----
-{prompt_sudo} zypper install python311
+{sudo} zypper install python311
 ----
 
 ==== Installation
@@ -82,7 +82,7 @@ For {slsa}-based operating systems, install the `ansible-trento` package using {
 
 [source,console,subs="attributes"]
 ----
-{prompt_sudo} zypper install ansible-trento
+{sudo} zypper install ansible-trento
 ----
 
 ==== Components
@@ -340,7 +340,7 @@ After the playbook runs, generate a support archive on any installed host with:
 
 [source,console,subs="attributes"]
 ----
-{prompt_sudo} supportconfig
+{sudo} supportconfig
 ----
 
 The resulting tarball includes the Trento-specific data collected by the plugin and can be attached to {suse} support cases.

--- a/trento/adoc/trento-install-agents.adoc
+++ b/trento/adoc/trento-install-agents.adoc
@@ -27,10 +27,10 @@ Install the {tragent} on an {sap} host and register it with the
 . Install the package:
 +
 ====
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo zypper ref
-sudo zypper install trento-agent
+{sudo} zypper ref
+{sudo} zypper install trento-agent
 ----
 ====
 +
@@ -82,17 +82,17 @@ openssl x509 -in mycert.crt -out mycert.pem -outform PEM
 . Start the {tragent}:
 +
 ====
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo systemctl enable --now trento-agent
+{sudo} systemctl enable --now trento-agent
 ----
 ====
 . Check the status of the {tragent}:
 +
 ====
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo systemctl status trento-agent
+{sudo} systemctl status trento-agent
 
 ● trento-agent.service - Trento Agent service
      Loaded: loaded (/usr/lib/systemd/system/trento-agent.service; enabled; vendor preset: disabled)
@@ -157,4 +157,3 @@ These parameters apply when `prometheus-mode` is set to `push`, which is require
 `+prometheus-tls-client-key+`:: Path to client private key file for mTLS authentication. Required when `prometheus-auth` is set to `mtls`. Used by `trento-agent generate alloy` only.
 
 NOTE: The `trento-agent generate alloy` command reads these parameters to generate the {grafana} Alloy configuration file. See the {prometheus} integration documentation for detailed instructions on deploying the generated configuration.
-

--- a/trento/adoc/trento-install-agents.adoc
+++ b/trento/adoc/trento-install-agents.adoc
@@ -27,15 +27,21 @@ Install the {tragent} on an {sap} host and register it with the
 . Install the package:
 +
 ====
-[source,bash,subs="attributes"]
+[source,bash]
 ----
-{prompt_sudo}zypper ref
-{prompt_sudo}zypper install trento-agent
+sudo zypper ref
+sudo zypper install trento-agent
 ----
 ====
 +
 A configuration file named `+/agent.yaml+` is created under `+/etc/trento/+` in {sles4sap} 15
 or under `+/usr/etc/trento/+` in {sles4sap} 16.
++
+[NOTE]
+====
+To protect sensitive information, the `agent.yaml` configuration file is automatically created with `600` permissions so that only the `root` user can read or modify it.
+====
+
 . Open the configuration file and uncomment
 (remove the `+#+` character) the entries for `+facts-service-url+`,
 `+server-url+` and `+api-key+`. Update the values if necessary:
@@ -76,17 +82,18 @@ openssl x509 -in mycert.crt -out mycert.pem -outform PEM
 . Start the {tragent}:
 +
 ====
-[source,bash,subs="attributes"]
+[source,bash]
 ----
-{prompt_sudo}systemctl enable --now trento-agent
+sudo systemctl enable --now trento-agent
 ----
 ====
 . Check the status of the {tragent}:
 +
 ====
-[source,bash,subs="attributes"]
+[source,bash]
 ----
-{prompt_sudo}systemctl status trento-agent
+sudo systemctl status trento-agent
+
 ● trento-agent.service - Trento Agent service
      Loaded: loaded (/usr/lib/systemd/system/trento-agent.service; enabled; vendor preset: disabled)
      Active: active (running) since Wed 2021-11-24 17:37:46 UTC; 4s ago

--- a/trento/adoc/trento-mcp-host-sles.adoc
+++ b/trento/adoc/trento-mcp-host-sles.adoc
@@ -21,10 +21,10 @@ include::partials/mcp-host-prerequisites.adoc[]
 
 To install {mcp_host}, open a terminal and run the following commands:
 
-[source,console]
+[source,console,subs="attributes"]
 ----
-sudo zypper refresh
-sudo zypper install mcphost
+{sudo} zypper refresh
+{sudo} zypper install mcphost
 ----
 
 After installation, verify that {mcp_host} is available and working by checking its version:

--- a/trento/adoc/trento-systemd-install.adoc
+++ b/trento/adoc/trento-systemd-install.adoc
@@ -178,6 +178,11 @@ https://www.rabbitmq.com/production-checklist.html[RabbitMQ guide].
 
 . Create a new RabbitMQ user:
 +
+[NOTE]
+====
+The values `TRENTO_USER` and `TRENTO_USER_PASSWORD` are placeholders. Replace them with your own secure values before running these commands.
+====
++
 [source,bash,subs="attributes"]
 ----
 {sudo} rabbitmqctl add_user TRENTO_USER TRENTO_USER_PASSWORD
@@ -227,6 +232,11 @@ openssl rand -out /dev/stdout 48 | base64
 ====
 
 . Create the `/etc/trento/trento-web` configuration file. For example:
++
+[NOTE]
+====
+The values `TRENTO_USER`, `TRENTO_USER_PASSWORD`, and `WEB_PASSWORD` are placeholders. Replace them with your own secure values before running these commands.
+====
 +
 [source,bash]
 ----
@@ -281,6 +291,11 @@ SMTP_PASSWORD=<<SMTP_PASSWORD>>
 ----
 
 . Create the `/etc/trento/trento-wanda` configuration file. For example:
++
+[NOTE]
+====
+The values `WANDA_USER`, `WANDA_PASSWORD`, `TRENTO_USER`, and `TRENTO_USER_PASSWORD` are placeholders. Replace them with your own secure values before running these commands.
+====
 +
 [source,bash]
 ----
@@ -499,10 +514,11 @@ server {
 ===== Prepare SSL certificate for NGINX
 
 Create or provide a certificate for https://nginx.org/en/[NGINX] to
-enable SSL for {trento}. To create the certificate, you can choose one of the following methods:
+enable SSL for {trento}. Choose one of the following methods:
 
 * To manually generate a self-signed certificate, see <<option-1-creating-a-self-signed-certificate>>.
 * To automate obtaining a signed certificate with Let's Encrypt, see <<option-2-using-lets-encrypt-for-a-signed-certificate-using-packagehub-repository>>.
+* To provide an existing signed certificate, you can use the procedure in <<option-1-creating-a-self-signed-certificate>>, skipping step 1 and adapting the remaining steps to use your own files.
 
 [[option-1-creating-a-self-signed-certificate]]
 ====== Create a self-signed certificate

--- a/trento/adoc/trento-systemd-install.adoc
+++ b/trento/adoc/trento-systemd-install.adoc
@@ -73,13 +73,13 @@ CREATE DATABASE trento_event_store;
 +
 [NOTE]
 ====
-The following commands use `wanda_user`, `wanda_password`, `trento_user`, and `trento_password` as example values. For a secure environment, replace the passwords (and user names, if needed) with your own secure values.
+The values `WANDA_USER`, `WANDA_PASSWORD`, `TRENTO_USER`, and `WEB_PASSWORD` are placeholders. Replace them with your own secure values before running these commands.
 ====
 +
 [source,sql]
 ----
-CREATE USER wanda_user WITH PASSWORD 'wanda_password';
-CREATE USER trento_user WITH PASSWORD 'web_password';
+CREATE USER WANDA_USER WITH PASSWORD 'WANDA_PASSWORD';
+CREATE USER TRENTO_USER WITH PASSWORD 'WEB_PASSWORD';
 ----
 
 . Grant required privileges to the users and close the connection:
@@ -87,11 +87,11 @@ CREATE USER trento_user WITH PASSWORD 'web_password';
 [source,sql]
 ----
 \c wanda
-GRANT ALL ON SCHEMA public TO wanda_user;
+GRANT ALL ON SCHEMA public TO WANDA_USER;
 \c trento
-GRANT ALL ON SCHEMA public TO trento_user;
+GRANT ALL ON SCHEMA public TO TRENTO_USER;
 \c trento_event_store
-GRANT ALL ON SCHEMA public TO trento_user;
+GRANT ALL ON SCHEMA public TO TRENTO_USER;
 \q
 ----
 
@@ -119,8 +119,8 @@ documentation.
 +
 [source,text]
 ----
-host   wanda                      wanda_user    0.0.0.0/0     scram-sha-256
-host   trento,trento_event_store  trento_user   0.0.0.0/0     scram-sha-256
+host   wanda                      WANDA_USER    0.0.0.0/0     scram-sha-256
+host   trento,trento_event_store  TRENTO_USER   0.0.0.0/0     scram-sha-256
 ----
 
 . Allow PostgreSQL to bind on all network interfaces in
@@ -180,7 +180,7 @@ https://www.rabbitmq.com/production-checklist.html[RabbitMQ guide].
 +
 [source,bash,subs="attributes"]
 ----
-{sudo} rabbitmqctl add_user trento_user trento_user_password
+{sudo} rabbitmqctl add_user TRENTO_USER TRENTO_USER_PASSWORD
 ----
 
 . Create a virtual host:
@@ -194,7 +194,7 @@ https://www.rabbitmq.com/production-checklist.html[RabbitMQ guide].
 +
 [source,bash,subs="attributes"]
 ----
-{sudo} rabbitmqctl set_permissions -p vhost trento_user ".*" ".*" ".*"
+{sudo} rabbitmqctl set_permissions -p vhost TRENTO_USER ".*" ".*" ".*"
 ----
 
 ===== Install {trento} using RPM packages
@@ -231,9 +231,9 @@ openssl rand -out /dev/stdout 48 | base64
 [source,bash]
 ----
 # /etc/trento/trento-web
-AMQP_URL=amqp://trento_user:trento_user_password@localhost:5672/vhost
-DATABASE_URL=ecto://trento_user:web_password@localhost/trento
-EVENTSTORE_URL=ecto://trento_user:web_password@localhost/trento_event_store
+AMQP_URL=amqp://TRENTO_USER:TRENTO_USER_PASSWORD@localhost:5672/vhost
+DATABASE_URL=ecto://TRENTO_USER:WEB_PASSWORD@localhost/trento
+EVENTSTORE_URL=ecto://TRENTO_USER:WEB_PASSWORD@localhost/trento_event_store
 ENABLE_ALERTING=false
 CHARTS_ENABLED=false
 ADMIN_USER=admin
@@ -286,8 +286,8 @@ SMTP_PASSWORD=<<SMTP_PASSWORD>>
 ----
 # /etc/trento/trento-wanda
 CORS_ORIGIN=http://localhost
-AMQP_URL=amqp://trento_user:trento_user_password@localhost:5672/vhost
-DATABASE_URL=ecto://wanda_user:wanda_password@localhost/wanda
+AMQP_URL=amqp://TRENTO_USER:TRENTO_USER_PASSWORD@localhost:5672/vhost
+DATABASE_URL=ecto://WANDA_USER:WANDA_PASSWORD@localhost/wanda
 PORT=4001
 SECRET_KEY_BASE=some-secret
 OAS_SERVER_URL=https://trento.example.com/wanda

--- a/trento/adoc/trento-systemd-install.adoc
+++ b/trento/adoc/trento-systemd-install.adoc
@@ -37,16 +37,16 @@ https://www.postgresql.org/docs/[PostgreSQL documentation].
 
 . Install PostgreSQL server:
 +
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo zypper install postgresql-server
+{sudo} zypper install postgresql-server
 ----
 
 . Enable and start PostgreSQL server:
 +
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo systemctl enable --now postgresql
+{sudo} systemctl enable --now postgresql
 ----
 
 ====== Configure PostgreSQL
@@ -54,9 +54,9 @@ sudo systemctl enable --now postgresql
 . Start `+psql+` with the `+postgres+` user to open a connection to the
 database:
 +
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo su - postgres
+{sudo} su - postgres
 psql
 ----
 
@@ -133,18 +133,18 @@ listen_addresses = '*'
 
 . Restart PostgreSQL to apply the changes:
 +
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo systemctl restart postgresql
+{sudo} systemctl restart postgresql
 ----
 
 ====== Install RabbitMQ
 
 . Install RabbitMQ server:
 +
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo zypper install rabbitmq-server
+{sudo} zypper install rabbitmq-server
 ----
 
 . Allow connections from external hosts by modifying
@@ -157,17 +157,17 @@ listeners.tcp.default = 5672
 
 . If firewalld is running, add a rule to firewalld:
 +
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo firewall-cmd --zone=public --add-port=5672/tcp --permanent
-sudo firewall-cmd --reload
+{sudo} firewall-cmd --zone=public --add-port=5672/tcp --permanent
+{sudo} firewall-cmd --reload
 ----
 
 . Enable the RabbitMQ service:
 +
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo systemctl enable --now rabbitmq-server
+{sudo} systemctl enable --now rabbitmq-server
 ----
 
 ====== Configure RabbitMQ
@@ -178,23 +178,23 @@ https://www.rabbitmq.com/production-checklist.html[RabbitMQ guide].
 
 . Create a new RabbitMQ user:
 +
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo rabbitmqctl add_user trento_user trento_user_password
+{sudo} rabbitmqctl add_user trento_user trento_user_password
 ----
 
 . Create a virtual host:
 +
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo rabbitmqctl add_vhost vhost
+{sudo} rabbitmqctl add_vhost vhost
 ----
 
 . Set permissions for the user on the virtual host:
 +
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo rabbitmqctl set_permissions -p vhost trento_user ".*" ".*" ".*"
+{sudo} rabbitmqctl set_permissions -p vhost trento_user ".*" ".*" ".*"
 ----
 
 ===== Install {trento} using RPM packages
@@ -203,9 +203,9 @@ The `trento-web` and `trento-wanda` packages are available by default on support
 
 Install {trento} web, wanda and checks:
 
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo zypper install trento-web trento-wanda
+{sudo} zypper install trento-web trento-wanda
 ----
 
 ====== Create the configuration files
@@ -298,10 +298,10 @@ AUTH_SERVER_URL=http://localhost:4000
 +
 To protect sensitive information, the configuration files must have `600` permissions so that only the `root` user can read them:
 +
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo chmod 600 /etc/trento/trento-web
-sudo chmod 600 /etc/trento/trento-wanda
+{sudo} chmod 600 /etc/trento/trento-web
+{sudo} chmod 600 /etc/trento/trento-wanda
 ----
 
 ====== Start the services
@@ -311,18 +311,18 @@ sudo chmod 600 /etc/trento/trento-wanda
 In some {sles4sap} environments, SELinux may be enabled and set to *enforcing* mode by default.  
 If {trento} services fail to start or show permission-related errors, check the SELinux status:
 
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo getenforce
+{sudo} getenforce
 ----
 
 If SELinux is set to *enforcing*, switch it to *permissive* mode either temporarily or permanently:
 
 * **Temporary change (until reboot):**
 +
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo setenforce 0
+{sudo} setenforce 0
 ----
 
 * **Permanent change (persists after reboot):**
@@ -337,9 +337,9 @@ SELINUX=permissive
 
 Enable and start the services:
 
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo systemctl enable --now trento-web trento-wanda
+{sudo} systemctl enable --now trento-web trento-wanda
 ----
 
 ====== Monitor the services
@@ -347,9 +347,9 @@ sudo systemctl enable --now trento-web trento-wanda
 Use `+journalctl+` to check if the services are up and running
 correctly. For example:
 
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo journalctl -fu trento-web
+{sudo} journalctl -fu trento-web
 ----
 
 [[validate-the-health-status-of-trento-web-and-wanda]]
@@ -395,23 +395,23 @@ curl http://localhost:4001/api/healthz
 
 . Install NGINX package:
 +
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo zypper install nginx
+{sudo} zypper install nginx
 ----
 . If firewalld is running, add firewalld rules for HTTP and HTTPS:
 +
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo firewall-cmd --zone=public --add-service=https --permanent
-sudo firewall-cmd --zone=public --add-service=http --permanent
-sudo firewall-cmd --reload
+{sudo} firewall-cmd --zone=public --add-service=https --permanent
+{sudo} firewall-cmd --zone=public --add-service=http --permanent
+{sudo} firewall-cmd --reload
 ----
 . Start and enable NGINX:
 +
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo systemctl enable --now nginx
+{sudo} systemctl enable --now nginx
 ----
 . Create a `+/etc/nginx/conf.d/trento.conf+` {trento} configuration file:
 +
@@ -526,24 +526,24 @@ openssl req -newkey rsa:2048 --nodes -keyout trento.key -x509 -days 5 -out trent
 
 . Copy the generated `+trento.key+` to a location accessible by NGINX:
 +
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo cp trento.key /etc/ssl/private/trento.key
+{sudo} cp trento.key /etc/ssl/private/trento.key
 ----
 
 . Create a directory for the generated `+trento.crt+` file. The
 directory must be accessible by NGINX:
 +
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo mkdir -p /etc/nginx/ssl/certs/
+{sudo} mkdir -p /etc/nginx/ssl/certs/
 ----
 
 . Copy the generated `+trento.crt+` file to the created directory:
 +
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo cp trento.crt /etc/nginx/ssl/certs/trento.crt
+{sudo} cp trento.crt /etc/nginx/ssl/certs/trento.crt
 ----
 
 . Ensure the self-signed certificate is trusted:
@@ -557,23 +557,23 @@ openssl x509 -in trento.crt -out trento.pem -outform PEM
 
 .. Copy the certificate in PEM format to `/etc/pki/trust/anchors/`:
 +
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo cp trento.pem /etc/pki/trust/anchors/
+{sudo} cp trento.pem /etc/pki/trust/anchors/
 ----
 
 .. Run the `update-ca-certificates` command:
 +
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo update-ca-certificates
+{sudo} update-ca-certificates
 ----
 
 . Check the NGINX configuration:
 +
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo nginx -t
+{sudo} nginx -t
 ----
 +
 If the configuration is correct, the output should be as follows:
@@ -588,9 +588,9 @@ If there are issues with the configuration, the output indicates what
 needs to be adjusted.
 . Enable NGINX:
 +
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo systemctl restart nginx
+{sudo} systemctl restart nginx
 ----
 
 [[option-2-using-lets-encrypt-for-a-signed-certificate-using-packagehub-repository]]
@@ -600,10 +600,10 @@ Automate obtaining a signed certificate with Let's Encrypt and configure NGINX t
 
 . Enable the PackageHub repository (replace `x.x` with your OS version, for example `15.7`):
 +
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo SUSEConnect --product PackageHub/x.x/x86_64
-sudo zypper refresh
+{sudo} SUSEConnect --product PackageHub/x.x/x86_64
+{sudo} zypper refresh
 ----
 
 . Find the Certbot NGINX plug-in package available in your current Service Pack:
@@ -624,9 +624,9 @@ S  | Name                    | Summary                  | Type
 
 . Install Certbot and its NGINX plug-in. Use the specific package name returned in the output of the previous step. For example:
 +
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo zypper install certbot python313-certbot-nginx
+{sudo} zypper install certbot python313-certbot-nginx
 ----
 
 . Obtain a certificate and configure NGINX with Certbot:
@@ -638,9 +638,9 @@ https://certbot.eff.org/instructions?ws=nginx&os=leap[Certbot
 instructions for NGINX]
 ====
 +
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo certbot --nginx -d trento.example.com
+{sudo} certbot --nginx -d trento.example.com
 ----
 +
 [NOTE]

--- a/trento/adoc/trento-systemd-install.adoc
+++ b/trento/adoc/trento-systemd-install.adoc
@@ -39,13 +39,14 @@ https://www.postgresql.org/docs/[PostgreSQL documentation].
 +
 [source,bash]
 ----
-zypper in postgresql-server
+sudo zypper install postgresql-server
 ----
+
 . Enable and start PostgreSQL server:
 +
 [source,bash]
 ----
-systemctl enable --now postgresql
+sudo systemctl enable --now postgresql
 ----
 
 ====== Configure PostgreSQL
@@ -55,9 +56,10 @@ database:
 +
 [source,bash]
 ----
-su - postgres
+sudo su - postgres
 psql
 ----
+
 . Initialize the databases in the `+psql+` console:
 +
 [source,sql]
@@ -66,13 +68,20 @@ CREATE DATABASE wanda;
 CREATE DATABASE trento;
 CREATE DATABASE trento_event_store;
 ----
+
 . Create the users:
++
+[NOTE]
+====
+The following commands use `wanda_user`, `wanda_password`, `trento_user`, and `trento_password` as example values. For a secure environment, replace the passwords (and user names, if needed) with your own secure values.
+====
 +
 [source,sql]
 ----
 CREATE USER wanda_user WITH PASSWORD 'wanda_password';
 CREATE USER trento_user WITH PASSWORD 'web_password';
 ----
+
 . Grant required privileges to the users and close the connection:
 +
 [source,sql]
@@ -81,44 +90,52 @@ CREATE USER trento_user WITH PASSWORD 'web_password';
 GRANT ALL ON SCHEMA public TO wanda_user;
 \c trento
 GRANT ALL ON SCHEMA public TO trento_user;
-\c trento_event_store;
+\c trento_event_store
 GRANT ALL ON SCHEMA public TO trento_user;
 \q
 ----
+
+. Exit the `+postgres+` user session:
 +
-You can exit from the `+psql+` console and `+postgres+` user.
+[source,sql]
+----
+exit
+----
+
 . Allow the PostgreSQL database to receive connections to the respective
 databases and users. To do this, add the following to
 `+/var/lib/pgsql/data/pg_hba.conf+`:
 +
-[source,bash]
-----
-host   wanda                      wanda_user    0.0.0.0/0     scram-sha-256
-host   trento,trento_event_store  trento_user   0.0.0.0/0     scram-sha-256
-----
-+
-[NOTE]
+[IMPORTANT]
 ====
 The `+pg_hba.conf+` file works sequentially. This means that the rules
-on the top have preference over the ones below. The example above shows
+on the top have preference over the ones below. The following example shows
 a permissive address range. So for this to work, the entires must be
 written at the top of the `+host+` entries. For further information,
 refer to the
 https://www.postgresql.org/docs/current/auth-pg-hba-conf.html[pg_hba.conf]
 documentation.
 ====
++
+[source,text]
+----
+host   wanda                      wanda_user    0.0.0.0/0     scram-sha-256
+host   trento,trento_event_store  trento_user   0.0.0.0/0     scram-sha-256
+----
+
 . Allow PostgreSQL to bind on all network interfaces in
 `+/var/lib/pgsql/data/postgresql.conf+` by changing the following line:
 +
-[source,bash]
+[source,ini]
 ----
 listen_addresses = '*'
 ----
+
 . Restart PostgreSQL to apply the changes:
 +
 [source,bash]
 ----
-systemctl restart postgresql
+sudo systemctl restart postgresql
 ----
 
 ====== Install RabbitMQ
@@ -127,27 +144,30 @@ systemctl restart postgresql
 +
 [source,bash]
 ----
-zypper install rabbitmq-server
+sudo zypper install rabbitmq-server
 ----
+
 . Allow connections from external hosts by modifying
 `+/etc/rabbitmq/rabbitmq.conf+`, so the {trento}-agent can reach RabbitMQ:
 +
-[source,ini files]
+[source,ini]
 ----
 listeners.tcp.default = 5672
 ----
+
 . If firewalld is running, add a rule to firewalld:
 +
 [source,bash]
 ----
-firewall-cmd --zone=public --add-port=5672/tcp --permanent;
-firewall-cmd --reload
+sudo firewall-cmd --zone=public --add-port=5672/tcp --permanent
+sudo firewall-cmd --reload
 ----
+
 . Enable the RabbitMQ service:
 +
 [source,bash]
 ----
-systemctl enable --now rabbitmq-server
+sudo systemctl enable --now rabbitmq-server
 ----
 
 ====== Configure RabbitMQ
@@ -160,19 +180,21 @@ https://www.rabbitmq.com/production-checklist.html[RabbitMQ guide].
 +
 [source,bash]
 ----
-rabbitmqctl add_user trento_user trento_user_password
+sudo rabbitmqctl add_user trento_user trento_user_password
 ----
+
 . Create a virtual host:
 +
 [source,bash]
 ----
-rabbitmqctl add_vhost vhost
+sudo rabbitmqctl add_vhost vhost
 ----
+
 . Set permissions for the user on the virtual host:
 +
 [source,bash]
 ----
-rabbitmqctl set_permissions -p vhost trento_user ".*" ".*" ".*"
+sudo rabbitmqctl set_permissions -p vhost trento_user ".*" ".*" ".*"
 ----
 
 ===== Install {trento} using RPM packages
@@ -183,7 +205,7 @@ Install {trento} web, wanda and checks:
 
 [source,bash]
 ----
-zypper install trento-web trento-wanda
+sudo zypper install trento-web trento-wanda
 ----
 
 ====== Create the configuration files
@@ -204,9 +226,8 @@ openssl rand -out /dev/stdout 48 | base64
 ----
 ====
 
-====== trento-web configuration
-
-====
+. Create the `/etc/trento/trento-web` configuration file. For example:
++
 [source,bash]
 ----
 # /etc/trento/trento-web
@@ -226,9 +247,8 @@ REFRESH_TOKEN_ENC_SECRET=some-secret
 CHECKS_SERVICE_BASE_URL=/wanda
 OAS_SERVER_URL=https://trento.example.com
 ----
-====
 
-* The `TRENTO_WEB_ORIGIN` configures internal functionalities such as the interactive API portal, websockets, or certificate generation.
+** The `TRENTO_WEB_ORIGIN` configures internal functionalities such as the interactive API portal, websockets, or certificate generation.
 +
 [IMPORTANT]
 ====
@@ -238,17 +258,16 @@ Otherwise, websocket connections will fail, preventing real-time updates
 in the web interface.
 ====
 
-* The `ADMIN_PASSWORD` variable must meet the following requiements:
+** The `ADMIN_PASSWORD` variable must meet the following requirements:
 	
-** Minimum of 8 characters
-** The password  not contain 3 consecutive identical numbers or letters (for example, 111 or aaa)
-** The password must not contain 4 consecutive  numbers or letters (for example, 1234, abcd, ABCD)
+*** Minimum of 8 characters
+*** The password  not contain 3 consecutive identical numbers or letters (for example, 111 or aaa)
+*** The password must not contain 4 consecutive  numbers or letters (for example, 1234, abcd, ABCD)
 
 
-* The `ENABLE_ALERTING` enables the 
-https://www.trento-project.io/docs/web/Alerting/alerting.html[alerting system to receive email notifications]. Set `ENABLE_ALERTING` to `true` and add additional variables to the `/etc/trento/trento-web`, to enable the feature:
+** The `ENABLE_ALERTING` enables the 
+https://www.trento-project.io/docs/web/Alerting/alerting.html[alerting system to receive email notifications]. Set `ENABLE_ALERTING` to `true` and add additional variables to the `/etc/trento/trento-web` to enable the feature:
 +
-====
 [source,bash]
 ----
 # /etc/trento/trento-web
@@ -260,11 +279,9 @@ SMTP_PORT=<<SMTP_PORT>>
 SMTP_USER=<<SMTP_USER>>
 SMTP_PASSWORD=<<SMTP_PASSWORD>>
 ----
-====
 
-====== trento-wanda configuration
-
-====
+. Create the `/etc/trento/trento-wanda` configuration file. For example:
++
 [source,bash]
 ----
 # /etc/trento/trento-wanda
@@ -276,7 +293,16 @@ SECRET_KEY_BASE=some-secret
 OAS_SERVER_URL=https://trento.example.com/wanda
 AUTH_SERVER_URL=http://localhost:4000
 ----
-====
+
+. Secure the configuration files.
++
+To protect sensitive information, the configuration files must have `600` permissions so that only the `root` user can read them:
++
+[source,bash]
+----
+sudo chmod 600 /etc/trento/trento-web
+sudo chmod 600 /etc/trento/trento-wanda
+----
 
 ====== Start the services
 
@@ -287,7 +313,7 @@ If {trento} services fail to start or show permission-related errors, check the 
 
 [source,bash]
 ----
-getenforce
+sudo getenforce
 ----
 
 If SELinux is set to *enforcing*, switch it to *permissive* mode either temporarily or permanently:
@@ -296,26 +322,24 @@ If SELinux is set to *enforcing*, switch it to *permissive* mode either temporar
 +
 [source,bash]
 ----
-setenforce 0
+sudo setenforce 0
 ----
 
 * **Permanent change (persists after reboot):**
 +
 Edit `/etc/selinux/config` and set:
 +
-[source]
+[source,ini]
 ----
 SELINUX=permissive
 ----
-+
-
 ====
 
 Enable and start the services:
 
 [source,bash]
 ----
-systemctl enable --now trento-web trento-wanda
+sudo systemctl enable --now trento-web trento-wanda
 ----
 
 ====== Monitor the services
@@ -325,14 +349,24 @@ correctly. For example:
 
 [source,bash]
 ----
-journalctl -fu trento-web
+sudo journalctl -fu trento-web
 ----
 
 [[validate-the-health-status-of-trento-web-and-wanda]]
 ===== Check the health status of {tr_web} and {tr_wanda}
 
 You can check if {tr_web} and {tr_wanda} services function correctly by
-accessing accessing the `+healthz+` and `+readyz+` API.
+accessing the `+healthz+` and `+readyz+` API.
+
+If {trento} web and wanda are ready, and the database connection is set up
+correctly, the output should be as follows:
+
+====
+[source,bash]
+----
+{"ready":true}{"database":"pass"}
+----
+====
 
 . Check {tr_web} health status using `+curl+`:
 +
@@ -345,7 +379,7 @@ curl http://localhost:4000/api/readyz
 ----
 curl http://localhost:4000/api/healthz
 ----
-. Check {trento} wanda health status using `+curl+`:
+. Check {tr_wanda} health status using `+curl+`:
 +
 [source,bash]
 ----
@@ -357,38 +391,27 @@ curl http://localhost:4001/api/readyz
 curl http://localhost:4001/api/healthz
 ----
 
-If {trento} web and wanda are ready, and the database connection is set up
-correctly, the output should be as follows:
-
-====
-[source,bash]
-----
-{"ready":true}{"database":"pass"}
-----
-====
-
-
 ===== Install and configure NGINX
 
 . Install NGINX package:
 +
 [source,bash]
 ----
-zypper install nginx
+sudo zypper install nginx
 ----
 . If firewalld is running, add firewalld rules for HTTP and HTTPS:
 +
 [source,bash]
 ----
-firewall-cmd --zone=public --add-service=https --permanent
-firewall-cmd --zone=public --add-service=http --permanent
-firewall-cmd --reload
+sudo firewall-cmd --zone=public --add-service=https --permanent
+sudo firewall-cmd --zone=public --add-service=http --permanent
+sudo firewall-cmd --reload
 ----
 . Start and enable NGINX:
 +
 [source,bash]
 ----
-systemctl enable --now nginx
+sudo systemctl enable --now nginx
 ----
 . Create a `+/etc/nginx/conf.d/trento.conf+` {trento} configuration file:
 +
@@ -476,10 +499,15 @@ server {
 ===== Prepare SSL certificate for NGINX
 
 Create or provide a certificate for https://nginx.org/en/[NGINX] to
-enable SSL for {trento}.
+enable SSL for {trento}. To create the certificate, you can choose one of the following methods:
+
+* To manually generate a self-signed certificate, see <<option-1-creating-a-self-signed-certificate>>.
+* To automate obtaining a signed certificate with Let's Encrypt, see <<option-2-using-lets-encrypt-for-a-signed-certificate-using-packagehub-repository>>.
 
 [[option-1-creating-a-self-signed-certificate]]
 ====== Create a self-signed certificate
+
+Manually generate a self-signed certificate and ensure it is trusted by the system.
 
 . Generate a self-signed certificate:
 +
@@ -495,24 +523,27 @@ example, `+-days 365+` for one year.
 ----
 openssl req -newkey rsa:2048 --nodes -keyout trento.key -x509 -days 5 -out trento.crt -addext "subjectAltName = DNS:trento.example.com"
 ----
+
 . Copy the generated `+trento.key+` to a location accessible by NGINX:
 +
 [source,bash]
 ----
-cp trento.key /etc/ssl/private/trento.key
+sudo cp trento.key /etc/ssl/private/trento.key
 ----
+
 . Create a directory for the generated `+trento.crt+` file. The
 directory must be accessible by NGINX:
 +
 [source,bash]
 ----
-mkdir -p /etc/nginx/ssl/certs/
+sudo mkdir -p /etc/nginx/ssl/certs/
 ----
+
 . Copy the generated `+trento.crt+` file to the created directory:
 +
 [source,bash]
 ----
-cp trento.crt /etc/nginx/ssl/certs/trento.crt
+sudo cp trento.crt /etc/nginx/ssl/certs/trento.crt
 ----
 
 . Ensure the self-signed certificate is trusted:
@@ -528,21 +559,21 @@ openssl x509 -in trento.crt -out trento.pem -outform PEM
 +
 [source,bash]
 ----
-cp trento.pem /etc/pki/trust/anchors/
+sudo cp trento.pem /etc/pki/trust/anchors/
 ----
 
 .. Run the `update-ca-certificates` command:
 +
 [source,bash]
 ----
-update-ca-certificates
+sudo update-ca-certificates
 ----
 
 . Check the NGINX configuration:
 +
 [source,bash]
 ----
-nginx -t
+sudo nginx -t
 ----
 +
 If the configuration is correct, the output should be as follows:
@@ -559,43 +590,57 @@ needs to be adjusted.
 +
 [source,bash]
 ----
-systemctl restart nginx
+sudo systemctl restart nginx
 ----
 
 [[option-2-using-lets-encrypt-for-a-signed-certificate-using-packagehub-repository]]
 ====== Create a signed certificate with Let's Encrypt using PackageHub repository
 
+Automate obtaining a signed certificate with Let's Encrypt and configure NGINX to use it.
+
 . Enable the PackageHub repository (replace `x.x` with your OS version, for example `15.7`):
 +
 [source,bash]
 ----
-SUSEConnect --product PackageHub/x.x/x86_64
-zypper refresh
+sudo SUSEConnect --product PackageHub/x.x/x86_64
+sudo zypper refresh
 ----
-+
-. Install Certbot and its NGINX plugin:
-+
-[NOTE]
-====
-Service Packs include version-specific Certbot NGINX plugin packages, for example `+python311-certbot-nginx+`, `+python313-certbot-nginx+` or `+python3-certbot-nginx+`. Install the package available in the Service Pack you currently use.
-====
+
+. Find the Certbot NGINX plug-in package available in your current Service Pack:
 +
 [source,bash]
 ----
-zypper install certbot python311-certbot-nginx
+zypper search certbot-nginx
 ----
++
+Example output:
++
+[source,bash]
+----
+S  | Name                    | Summary                  | Type
+---+-------------------------+--------------------------+--------
+   | python313-certbot-nginx | Nginx plugin for Certbot | package
+----
+
+. Install Certbot and its NGINX plug-in. Use the specific package name returned in the output of the previous step. For example:
++
+[source,bash]
+----
+sudo zypper install certbot python313-certbot-nginx
+----
+
 . Obtain a certificate and configure NGINX with Certbot:
 +
 [NOTE]
 ====
-Replace `+example.com+` with your domain. For more information, refer to
+Replace `+trento.example.com+` with your domain. For more information, refer to
 https://certbot.eff.org/instructions?ws=nginx&os=leap[Certbot
 instructions for NGINX]
 ====
 +
 [source,bash]
 ----
-certbot --nginx -d trento.example.com
+sudo certbot --nginx -d trento.example.com
 ----
 +
 [NOTE]

--- a/trento/adoc/trento-uninstall-trento-agent.adoc
+++ b/trento/adoc/trento-uninstall-trento-agent.adoc
@@ -13,7 +13,7 @@ To uninstall a {tragent}, perform the following steps:
 ====
 [source,bash,subs="attributes"]
 ----
-{prompt_sudo}systemctl stop trento-agent
+{sudo} systemctl stop trento-agent
 ----
 ====
 * Remove the package:
@@ -21,6 +21,6 @@ To uninstall a {tragent}, perform the following steps:
 ====
 [source,bash,subs="attributes"]
 ----
-{prompt_sudo}zypper remove trento-agent
+{sudo} zypper remove trento-agent
 ----
 ====

--- a/trento/adoc/trento-update-trento-agent.adoc
+++ b/trento/adoc/trento-update-trento-agent.adoc
@@ -13,7 +13,7 @@ To update the {tragent}, follow the procedure below:
 ====
 [source,bash,subs="attributes"]
 ----
-{prompt_sudo}systemctl stop trento-agent
+{sudo} systemctl stop trento-agent
 ----
 ====
 +
@@ -22,8 +22,8 @@ To update the {tragent}, follow the procedure below:
 ====
 [source,bash,subs="attributes"]
 ----
-{prompt_sudo}zypper ref
-{prompt_sudo}zypper install trento-agent
+{sudo} zypper ref
+{sudo} zypper install trento-agent
 ----
 ====
 +
@@ -36,16 +36,16 @@ To update the {tragent}, follow the procedure below:
 ====
 [source,bash,subs="attributes"]
 ----
-{prompt_sudo}systemctl start trento-agent
+{sudo} systemctl start trento-agent
 ----
 ====
 +
 . Check the status of the {tragent}:
 +
 ====
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-sudo systemctl status trento-agent
+{sudo} systemctl status trento-agent
 ● trento-agent.service - Trento Agent service
    Loaded: loaded (/usr/lib/systemd/system/trento-agent.service; enabled; vendor preset: disabled)
    Active: active (running) since Wed 2021-11-24 17:37:46 UTC; 4s ago

--- a/trento/adoc/trento-update-trento-checks.adoc
+++ b/trento/adoc/trento-update-trento-checks.adoc
@@ -30,7 +30,7 @@ can use Zypper to update your checks catalog:
 ====
 [source,bash,subs="attributes"]
 ----
-{prompt_sudo}zypper ref
-{prompt_sudo}zypper update trento-checks
+{sudo} zypper ref
+{sudo} zypper update trento-checks
 ----
 ====


### PR DESCRIPTION
### Description

New addition: information about `600` permissions, see comments:
https://github.com/trento-project/docs/pull/251#discussion_r3656658847, https://github.com/trento-project/docs/pull/251#discussion_r3656659973

The rest: structural improvements + adding sudo to commands and removing `{prompt_sudo}` because it copies with `>` symbol and therefore breaks the command if the user tries to copy-paste it

Fixes https://jira.suse.com/browse/TRNT-4575
<!-- Optionally use depends #<issue> for dependent PRs -->

### Preview
(before reviews) [SLES-SAP-trento_en.pdf](https://github.com/user-attachments/files/30410915/SLES-SAP-trento_en.pdf)

New preview (4 commits):
[SLES-SAP-trento_en.pdf](https://github.com/user-attachments/files/30459647/SLES-SAP-trento_en.pdf)



Chapters: 
- 4.1.2 systemd deployment
- 4.2 Installing Trento Agents
